### PR TITLE
Shorten numpy

### DIFF
--- a/src/quemb/kbe/autofrag.py
+++ b/src/quemb/kbe/autofrag.py
@@ -3,6 +3,7 @@
 import sys
 
 import numpy
+from numpy.linalg import norm
 from pyscf import lib
 
 from quemb.kbe.misc import sgeom
@@ -39,7 +40,7 @@ def nearestof2coord(coord1, coord2, bond=2.6 * 1.88973):
         for jdx, j in enumerate(coord2):
             if idx == jdx:
                 continue
-            dist = numpy.linalg.norm(i - j)
+            dist = norm(i - j)
 
             if dist < mind or dist - mind < 0.1:
                 if dist <= bond:
@@ -58,7 +59,7 @@ def nearestof2coord(coord1, coord2, bond=2.6 * 1.88973):
 
             if idx == lmin[0] and jdx == lmin[1]:
                 continue
-            dist = numpy.linalg.norm(i - j)
+            dist = norm(i - j)
             if dist - mind < 0.1 and dist <= bond:
                 lunit_.append(idx)
                 runit_.append(jdx)
@@ -110,7 +111,7 @@ def sidefunc(
                     and jdx not in unit2
                     and not cell.atom_pure_symbol(jdx) == "H"
                 ):
-                    dist = numpy.linalg.norm(coord[lmin1] - j)
+                    dist = norm(coord[lmin1] - j)
                     if dist <= bond:
                         if jdx not in sub_list:  # avoid repeated occurence
                             main_list.append(jdx)
@@ -126,7 +127,7 @@ def sidefunc(
                                         and kdx not in unit2
                                         and not cell.atom_pure_symbol(kdx) == "H"
                                     ):
-                                        dist = numpy.linalg.norm(coord[jdx] - k)
+                                        dist = norm(coord[jdx] - k)
                                         if dist <= bond:
                                             main_list.append(kdx)
                                             sub_list.append(kdx)
@@ -473,7 +474,7 @@ def autogen(
     # starts here
     normlist = []
     for i in coord:
-        normlist.append(numpy.linalg.norm(i))
+        normlist.append(norm(i))
     Frag = []
     pedge = []
     cen = []
@@ -509,7 +510,7 @@ def autogen(
                     continue
                 if ai[inter_layer_axis] == aj[inter_layer_axis]:
                     continue
-                dist = numpy.linalg.norm(ai - aj)
+                dist = norm(ai - aj)
                 if dist > bond:
                     if inter_dist > dist:
                         inter_dist = dist
@@ -520,7 +521,7 @@ def autogen(
                     continue
                 if ai[inter_layer_axis] == aj[inter_layer_axis]:
                     continue
-                dist = numpy.linalg.norm(ai - aj)
+                dist = norm(ai - aj)
                 if abs(dist - inter_dist) < perpend_dist_tol:
                     inter_dist_.append(dist)
                     inter_idx_.append(ajdx)
@@ -1313,7 +1314,7 @@ def autogen(
         cen.append(idx)
 
         for jdx in clist:
-            dist = numpy.linalg.norm(coord[idx] - coord[jdx])
+            dist = norm(coord[idx] - coord[jdx])
 
             if (dist <= bond) or (
                 interlayer
@@ -1348,7 +1349,7 @@ def autogen(
                                     or cell.atom_pure_symbol(kdx) == "H"
                                 ):
                                     continue
-                                dist = numpy.linalg.norm(coord[lmin1] - k)
+                                dist = norm(coord[lmin1] - k)
                                 if dist <= bond:
                                     if (
                                         kdx in lsts
@@ -1428,7 +1429,7 @@ def autogen(
                                     or cell.atom_pure_symbol(kdx) == "H"
                                 ):
                                     continue
-                                dist = numpy.linalg.norm(coord[rmin1] - k)
+                                dist = norm(coord[rmin1] - k)
                                 if dist <= bond:
                                     if (
                                         kdx in rsts
@@ -1499,7 +1500,7 @@ def autogen(
                                     or cell.atom_pure_symbol(kdx) == "H"
                                 ):
                                     continue
-                                dist = numpy.linalg.norm(coord[umin1] - k)
+                                dist = norm(coord[umin1] - k)
                                 if dist <= bond:
                                     if (
                                         kdx in usts
@@ -1567,7 +1568,7 @@ def autogen(
                                     or cell.atom_pure_symbol(kdx) == "H"
                                 ):
                                     continue
-                                dist = numpy.linalg.norm(coord[dmin1] - k)
+                                dist = norm(coord[dmin1] - k)
                                 if dist <= bond:
                                     if (
                                         kdx in dsts
@@ -1634,7 +1635,7 @@ def autogen(
                                     or cell.atom_pure_symbol(kdx) == "H"
                                 ):
                                     continue
-                                dist = numpy.linalg.norm(coord[mmin1] - k)
+                                dist = norm(coord[mmin1] - k)
                                 if dist <= bond:
                                     if (
                                         kdx in msts
@@ -1689,7 +1690,7 @@ def autogen(
                                     or cell.atom_pure_symbol(kdx) == "H"
                                 ):
                                     continue
-                                dist = numpy.linalg.norm(coord[tmin1] - k)
+                                dist = norm(coord[tmin1] - k)
                                 if dist <= bond:
                                     if (
                                         kdx in tsts
@@ -1734,7 +1735,7 @@ def autogen(
 
                     for kdx in clist:
                         if not kdx == jdx:
-                            dist = numpy.linalg.norm(coord[jdx] - coord[kdx])
+                            dist = norm(coord[jdx] - coord[kdx])
                             if (dist <= bond) or (
                                 interlayer
                                 and dist in inter_layer_dict[jdx][1]
@@ -1833,7 +1834,7 @@ def autogen(
                                             or ldx in pedg
                                         ):
                                             continue
-                                        dist = numpy.linalg.norm(coord[kdx] - l)
+                                        dist = norm(coord[kdx] - l)
                                         if dist <= bond:
                                             flist.append(ldx)
                                             pedg.append(ldx)
@@ -1867,7 +1868,7 @@ def autogen(
                         clist.append(jdx)
 
             for jdx in clist:
-                dist = numpy.linalg.norm(coord[idx] - coord[jdx])
+                dist = norm(coord[idx] - coord[jdx])
                 if dist <= hbond:
                     hlist[jdx].append(idx)
     if print_frags:

--- a/src/quemb/kbe/helper.py
+++ b/src/quemb/kbe/helper.py
@@ -1,8 +1,7 @@
 # Author(s): Oinam Romesh Meitei
 
-import functools
-
 import numpy
+from numpy.linalg import multi_dot
 from pyscf import scf
 
 from quemb.shared.helper import unused
@@ -37,7 +36,7 @@ def get_veff(eri_, dm, S, TA, hf_veff, return_veff0=False):
     P_ = numpy.zeros((neo, neo), dtype=numpy.complex128)
     for k in range(nk):
         Cinv = numpy.dot(TA[k].conj().T, S[k])
-        P_ += functools.reduce(numpy.dot, (Cinv, dm[k], Cinv.conj().T))
+        P_ += multi_dot((Cinv, dm[k], Cinv.conj().T))
     P_ /= float(nk)
 
     P_ = numpy.asarray(P_.real, dtype=numpy.double)
@@ -50,7 +49,7 @@ def get_veff(eri_, dm, S, TA, hf_veff, return_veff0=False):
 
     Veff0 = numpy.zeros((neo, neo), dtype=numpy.complex128)
     for k in range(nk):
-        Veff0 += functools.reduce(numpy.dot, (TA[k].conj().T, hf_veff[k], TA[k]))
+        Veff0 += multi_dot((TA[k].conj().T, hf_veff[k], TA[k]))
     Veff0 /= float(nk)
 
     Veff = Veff0 - Veff_

--- a/src/quemb/kbe/lo_k.py
+++ b/src/quemb/kbe/lo_k.py
@@ -29,7 +29,7 @@ def get_cano_orth_mat(A, thr=1.0e-7, ovlp=None):
 
 def cano_orth(A, thr=1.0e-7, ovlp=None):
     """Canonically orthogonalize columns of A"""
-    return get_cano_orth_mat(A, thr, ovlp)
+    return A @ get_cano_orth_mat(A, thr, ovlp)
 
 
 def get_symm_orth_mat_k(A, thr=1.0e-7, ovlp=None):

--- a/src/quemb/kbe/lo_k.py
+++ b/src/quemb/kbe/lo_k.py
@@ -2,11 +2,9 @@
 #            Oinam Meitei
 #
 
-from functools import reduce
-
 import numpy
 import scipy
-from numpy.linalg import eigh, inv, norm
+from numpy.linalg import eigh, inv, multi_dot, norm
 from pyscf.pbc import gto as pgto
 
 from quemb.shared.helper import unused
@@ -14,10 +12,9 @@ from quemb.shared.helper import unused
 
 def dot_gen(A, B, ovlp):
     if ovlp is None:
-        Ad = numpy.dot(A.conj().T, B)
+        return A.conj().T @ B
     else:
-        Ad = reduce(numpy.dot, (A.conj().T, ovlp, B))
-    return Ad
+        return A.conj().T @ ovlp @ B
 
 
 def get_cano_orth_mat(A, thr=1.0e-7, ovlp=None):
@@ -27,16 +24,12 @@ def get_cano_orth_mat(A, thr=1.0e-7, ovlp=None):
         idx_keep = e / e[-1] > thr
     else:
         idx_keep = list(range(e.shape[0]))
-    U = u[:, idx_keep] * e[idx_keep] ** -0.5
-
-    return U
+    return u[:, idx_keep] * e[idx_keep] ** -0.5
 
 
 def cano_orth(A, thr=1.0e-7, ovlp=None):
     """Canonically orthogonalize columns of A"""
-    U = get_cano_orth_mat(A, thr, ovlp)
-
-    return A @ U
+    return get_cano_orth_mat(A, thr, ovlp)
 
 
 def get_symm_orth_mat_k(A, thr=1.0e-7, ovlp=None):
@@ -48,17 +41,12 @@ def get_symm_orth_mat_k(A, thr=1.0e-7, ovlp=None):
             "smallest eigenvalue (%.3E) is less than thr (%.3E). "
             "Please use 'cano_orth' instead." % (numpy.min(e), thr)
         )
-    U = reduce(numpy.dot, (u, numpy.diag(e**-0.5), u.conj().T))
-    # U = reduce(numpy.dot, (u/numpy.sqrt(e), u.conj().T))
-    return U
+    return u @ numpy.diag(e**-0.5) @ u.conj().T
 
 
 def symm_orth_k(A, thr=1.0e-7, ovlp=None):
     """Symmetrically orthogonalize columns of A"""
-    U = get_symm_orth_mat_k(A, thr, ovlp)
-    AU = numpy.dot(A, U)
-
-    return AU
+    return A @ get_symm_orth_mat_k(A, thr, ovlp)
 
 
 def get_xovlp_k(cell, kpts, basis="sto-3g"):
@@ -126,21 +114,19 @@ def get_iao_k(Co, S12, S1, S2=None, ortho=True):
     Ciao = numpy.zeros((nk, nao, S12.shape[-1]), dtype=numpy.complex128)
     for k in range(nk):
         # Cotil = P1[k] @ S12[k] @ P2[k] @ S12[k].conj().T @ Co[k]
-        Cotil = reduce(numpy.dot, (P1[k], S12[k], P2[k], S12[k].conj().T, Co[k]))
+        Cotil = multi_dot((P1[k], S12[k], P2[k], S12[k].conj().T, Co[k]))
         ptil = numpy.dot(P1[k], S12[k])
-        Stil = reduce(numpy.dot, (Cotil.conj().T, S1[k], Cotil))
+        Stil = multi_dot((Cotil.conj().T, S1[k], Cotil))
 
         Po = numpy.dot(Co[k], Co[k].conj().T)
 
         Stil_inv = inv(Stil)
 
-        Potil = reduce(numpy.dot, (Cotil, Stil_inv, Cotil.conj().T))
+        Potil = multi_dot((Cotil, Stil_inv, Cotil.conj().T))
 
         Ciao[k] = (
             numpy.eye(nao, dtype=numpy.complex128)
-            - numpy.dot(
-                (Po + Potil - 2.0 * reduce(numpy.dot, (Po, S1[k], Potil))), S1[k]
-            )
+            - numpy.dot((Po + Potil - 2.0 * multi_dot((Po, S1[k], Potil))), S1[k])
         ) @ ptil
         if ortho:
             Ciao[k] = symm_orth_k(Ciao[k], ovlp=S1[k])
@@ -209,7 +195,7 @@ def get_pao_native_k(Ciao, S, mol, valence_basis, kpts, ortho=True):
     niao = len(vir_idx)
     Cpao = numpy.zeros((nk, nao, niao), dtype=numpy.complex128)
     for k in range(nk):
-        Piao = reduce(numpy.dot, (Ciao[k], Ciao[k].conj().T, S[k]))
+        Piao = multi_dot((Ciao[k], Ciao[k].conj().T, S[k]))
         cpao_ = (numpy.eye(nao) - Piao)[:, vir_idx]
         if ortho:
             try:

--- a/src/quemb/kbe/lo_k.py
+++ b/src/quemb/kbe/lo_k.py
@@ -131,7 +131,7 @@ def get_iao_k(Co, S12, S1, S2=None, ortho=True):
         if ortho:
             Ciao[k] = symm_orth_k(Ciao[k], ovlp=S1[k])
 
-            rep_err = norm(Ciao[k] @ Ciao[k].conj().T @ S1[k] @ Po - Po)
+            rep_err = norm(multi_dot(Ciao[k], Ciao[k].conj().T, S1[k], Po) - Po)
             if rep_err > 1.0e-10:
                 raise RuntimeError
 

--- a/src/quemb/kbe/lo_k.py
+++ b/src/quemb/kbe/lo_k.py
@@ -6,6 +6,7 @@ from functools import reduce
 
 import numpy
 import scipy
+from numpy.linalg import eigh, inv, norm
 from pyscf.pbc import gto as pgto
 
 from quemb.shared.helper import unused
@@ -21,7 +22,7 @@ def dot_gen(A, B, ovlp):
 
 def get_cano_orth_mat(A, thr=1.0e-7, ovlp=None):
     S = dot_gen(A, A, ovlp)
-    e, u = numpy.linalg.eigh(S)
+    e, u = eigh(S)
     if thr > 0:
         idx_keep = e / e[-1] > thr
     else:
@@ -131,7 +132,7 @@ def get_iao_k(Co, S12, S1, S2=None, ortho=True):
 
         Po = numpy.dot(Co[k], Co[k].conj().T)
 
-        Stil_inv = numpy.linalg.inv(Stil)
+        Stil_inv = inv(Stil)
 
         Potil = reduce(numpy.dot, (Cotil, Stil_inv, Cotil.conj().T))
 
@@ -144,7 +145,7 @@ def get_iao_k(Co, S12, S1, S2=None, ortho=True):
         if ortho:
             Ciao[k] = symm_orth_k(Ciao[k], ovlp=S1[k])
 
-            rep_err = numpy.linalg.norm(Ciao[k] @ Ciao[k].conj().T @ S1[k] @ Po - Po)
+            rep_err = norm(Ciao[k] @ Ciao[k].conj().T @ S1[k] @ Po - Po)
             if rep_err > 1.0e-10:
                 raise RuntimeError
 

--- a/src/quemb/kbe/pfrag.py
+++ b/src/quemb/kbe/pfrag.py
@@ -1,10 +1,10 @@
 # Author(s): Oinam Romesh Meitei
 
-import functools
 import sys
 
 import h5py
 import numpy
+from numpy.linalg import multi_dot
 
 from quemb.kbe.helper import get_veff
 from quemb.kbe.misc import get_phase, get_phase1
@@ -180,16 +180,12 @@ class Frags:
         # useful for debugging --
         rdm1_eo = numpy.zeros((teo, teo), dtype=numpy.complex128)
         for k in range(nk):
-            rdm1_eo += functools.reduce(
-                numpy.dot, (TA_k[k].conj().T, rdm1_lo_k[k], TA_k[k])
-            )
+            rdm1_eo += multi_dot((TA_k[k].conj().T, rdm1_lo_k[k], TA_k[k]))
         rdm1_eo /= float(nk)
 
         h1_eo = numpy.zeros((teo, teo), dtype=numpy.complex128)
         for k in range(nk):
-            h1_eo += functools.reduce(
-                numpy.dot, (self.TA[k].conj().T, h1[k], self.TA[k])
-            )
+            h1_eo += multi_dot((self.TA[k].conj().T, h1[k], self.TA[k]))
         h1_eo /= float(nk)
         e1 = 2.0 * numpy.einsum(
             "ij,ij->i", h1_eo[: self.nfsites], rdm1_eo[: self.nfsites]
@@ -212,9 +208,7 @@ class Frags:
         unused(nao)
         h1_eo = numpy.zeros((teo, teo), dtype=numpy.complex128)
         for k in range(nk):
-            h1_eo += functools.reduce(
-                numpy.dot, (self.TA[k].conj().T, h1[k], self.TA[k])
-            )
+            h1_eo += multi_dot((self.TA[k].conj().T, h1[k], self.TA[k]))
         h1_eo /= float(nk)
 
         if numpy.abs(h1_eo.imag).max() < 1.0e-7:
@@ -283,7 +277,7 @@ class Frags:
         P_ = numpy.zeros((neo, neo), dtype=numpy.complex128)
         for k in range(nk):
             Cinv = numpy.dot(self.TA[k].conj().T, S[k])
-            P_ += functools.reduce(numpy.dot, (Cinv, dm_[k], Cinv.conj().T))
+            P_ += multi_dot((Cinv, dm_[k], Cinv.conj().T))
 
         P_ /= float(nk)
         if numpy.abs(P_.imag).max() < 1.0e-6:

--- a/src/quemb/molbe/autofrag.py
+++ b/src/quemb/molbe/autofrag.py
@@ -2,7 +2,7 @@
 
 import sys
 
-import numpy
+from numpy.linalg import norm
 
 from quemb.molbe.helper import get_core
 from quemb.shared.helper import unused
@@ -100,7 +100,7 @@ def autogen(
     # Compute the norm (magnitude) of each atomic coordinate
     normlist = []
     for i in coord:
-        normlist.append(numpy.linalg.norm(i))
+        normlist.append(norm(i))
     Frag = []
     pedge = []
     cen = []
@@ -134,14 +134,14 @@ def autogen(
 
         if not be_type == "be1":
             for jdx in clist:
-                dist = numpy.linalg.norm(coord[idx] - coord[jdx])
+                dist = norm(coord[idx] - coord[jdx])
                 if dist <= bond:
                     flist.append(jdx)
                     pedg.append(jdx)
                     if be_type == "be3" or be_type == "be4":
                         for kdx in clist:
                             if not kdx == jdx:
-                                dist = numpy.linalg.norm(coord[jdx] - coord[kdx])
+                                dist = norm(coord[jdx] - coord[kdx])
                                 if dist <= bond:
                                     if kdx not in pedg:
                                         flist.append(kdx)
@@ -158,7 +158,7 @@ def autogen(
                                                 or ldx in pedg
                                             ):
                                                 continue
-                                            dist = numpy.linalg.norm(coord[kdx] - l)
+                                            dist = norm(coord[kdx] - l)
                                             if dist <= bond:
                                                 flist.append(ldx)
                                                 pedg.append(ldx)
@@ -198,7 +198,7 @@ def autogen(
                         if abs(j) < normdist:
                             clist.append(jdx)
                 for jdx in clist:
-                    dist = numpy.linalg.norm(coord[idx] - coord[jdx])
+                    dist = norm(coord[idx] - coord[jdx])
                     if dist <= hbond:
                         hlist[jdx].append(idx)
 

--- a/src/quemb/molbe/be_parallel.py
+++ b/src/quemb/molbe/be_parallel.py
@@ -6,6 +6,7 @@ import sys
 from multiprocessing import Pool
 
 import numpy
+from numpy.linalg import multi_dot
 from pyscf import ao2mo, fci, mcscf
 
 from quemb.molbe.helper import (
@@ -157,7 +158,7 @@ def run_solver(
         ci_.ci_coeff_cutoff = ci_coeff_cutoff
 
         nelec = (nocc, nocc)
-        h1_ = functools.reduce(numpy.dot, (mf_.mo_coeff.T, h1, mf_.mo_coeff))
+        h1_ = multi_dot((mf_.mo_coeff.T, h1, mf_.mo_coeff))
         eci, civec = ci_.kernel(h1_, eri, nmo, nelec)
         unused(eci)
         civec = numpy.asarray(civec)
@@ -214,7 +215,7 @@ def run_solver(
         sys.exit()
 
     # Compute RDM1
-    rdm1 = functools.reduce(numpy.dot, (mf_.mo_coeff, rdm1_tmp, mf_.mo_coeff.T)) * 0.5
+    rdm1 = multi_dot((mf_.mo_coeff, rdm1_tmp, mf_.mo_coeff.T)) * 0.5
     if eeval:
         if solver == "CCSD" and not rdm_return:
             with_dm1 = True

--- a/src/quemb/molbe/be_parallel.py
+++ b/src/quemb/molbe/be_parallel.py
@@ -1,6 +1,5 @@
 # Author(s): Oinam Romesh Meitei, Leah Weisburn
 
-import functools
 import os
 import sys
 from multiprocessing import Pool
@@ -345,18 +344,12 @@ def run_solver_u(
     # Compute RDM1
     fobj_a.rdm1__ = rdm1_tmp[0].copy()
     fobj_a._rdm1 = (
-        functools.reduce(
-            numpy.dot, (fobj_a._mf.mo_coeff, rdm1_tmp[0], fobj_a._mf.mo_coeff.T)
-        )
-        * 0.5
+        multi_dot((fobj_a._mf.mo_coeff, rdm1_tmp[0], fobj_a._mf.mo_coeff.T)) * 0.5
     )
 
     fobj_b.rdm1__ = rdm1_tmp[1].copy()
     fobj_b._rdm1 = (
-        functools.reduce(
-            numpy.dot, (fobj_b._mf.mo_coeff, rdm1_tmp[1], fobj_b._mf.mo_coeff.T)
-        )
-        * 0.5
+        multi_dot((fobj_b._mf.mo_coeff, rdm1_tmp[1], fobj_b._mf.mo_coeff.T)) * 0.5
     )
 
     # Calculate Energies

--- a/src/quemb/molbe/helper.py
+++ b/src/quemb/molbe/helper.py
@@ -1,10 +1,10 @@
 # Author(s): Oinam Romesh Meitei
 #            Leah Weisburn
 
-import functools
 
 import h5py
 import numpy
+from numpy.linalg import multi_dot
 from pyscf import ao2mo, gto, lib, scf
 
 from quemb.shared.helper import ncore_
@@ -39,7 +39,7 @@ def get_veff(eri_, dm, S, TA, hf_veff):
 
     # Transform the density matrix
     ST = numpy.dot(S, TA)
-    P_ = functools.reduce(numpy.dot, (ST.T, dm, ST))
+    P_ = multi_dot((ST.T, dm, ST))
 
     # Ensure the transformed density matrix and ERI are real and double-precision
     P_ = numpy.asarray(P_.real, dtype=numpy.double)
@@ -48,7 +48,7 @@ def get_veff(eri_, dm, S, TA, hf_veff):
     # Compute the Coulomb (J) and exchange (K) integrals
     vj, vk = scf.hf.dot_eri_dm(eri_, P_, hermi=1, with_j=True, with_k=True)
     Veff_ = vj - 0.5 * vk
-    Veff = functools.reduce(numpy.dot, (TA.T, hf_veff, TA)) - Veff_
+    Veff = multi_dot((TA.T, hf_veff, TA)) - Veff_
 
     return Veff
 
@@ -275,7 +275,7 @@ def get_frag_energy(
 
     if veff0 is None:
         # Compute the effective potential in the transformed basis
-        veff0 = functools.reduce(numpy.dot, (TA.T, hf_veff, TA))
+        veff0 = multi_dot((TA.T, hf_veff, TA))
 
     # Calculate the one-electron and effective potential energy contributions
     e1 = numpy.einsum("ij,ij->i", h1[:nfsites], delta_rdm1[:nfsites])
@@ -400,9 +400,7 @@ def get_frag_energy_u(
 
     if veff0 is None:
         # Compute thte effective potential in the transformed basis
-        veff0 = [
-            functools.reduce(numpy.dot, (TA[s].T, hf_veff[s], TA[s])) for s in [0, 1]
-        ]
+        veff0 = [multi_dot((TA[s].T, hf_veff[s], TA[s])) for s in [0, 1]]
 
     # For frozen care, remove core potential and Hamiltonian components
     if frozen:

--- a/src/quemb/molbe/lo.py
+++ b/src/quemb/molbe/lo.py
@@ -262,38 +262,32 @@ class MixinLocalize:
                         for s in [0, 1]
                     ]
                     C_ = numpy.dot(P_core, self.W)
-                    Cpop = [
-                        functools.reduce(numpy.dot, (C_[s].T, self.S, C_[s]))
-                        for s in [0, 1]
-                    ]
+                    Cpop = [multi_dot((C_[s].T, self.S, C_[s])) for s in [0, 1]]
                     Cpop = [numpy.diag(Cpop[s]) for s in [0, 1]]
                     no_core_idx = [numpy.where(Cpop[s] > 0.7)[0] for s in [0, 1]]
                     C_ = [C_[s][:, no_core_idx[s]] for s in [0, 1]]
-                    S_ = [
-                        functools.reduce(numpy.dot, (C_[s].T, self.S, C_[s]))
-                        for s in [0, 1]
-                    ]
+                    S_ = [multi_dot((C_[s].T, self.S, C_[s])) for s in [0, 1]]
                     W_ = []
                     for s in [0, 1]:
                         es_, vs_ = eigh(S_[s])
                         s_ = numpy.sqrt(es_)
                         s_ = numpy.diag(1.0 / s_)
-                        W_.append(functools.reduce(numpy.dot, (vs_, s_, vs_.T)))
+                        W_.append(multi_dot((vs_, s_, vs_.T)))
                     self.W = [numpy.dot(C_[s], W_[s]) for s in [0, 1]]
                 else:
                     P_core = numpy.eye(self.W.shape[0]) - numpy.dot(self.P_core, self.S)
                     C_ = numpy.dot(P_core, self.W)
                     # NOTE: PYSCF has basis in 1s2s3s2p2p2p3p3p3p format
                     # fix no_core_idx - use population for now
-                    Cpop = functools.reduce(numpy.dot, (C_.T, self.S, C_))
+                    Cpop = multi_dot((C_.T, self.S, C_))
                     Cpop = numpy.diag(Cpop)
                     no_core_idx = numpy.where(Cpop > 0.7)[0]
                     C_ = C_[:, no_core_idx]
-                    S_ = functools.reduce(numpy.dot, (C_.T, self.S, C_))
+                    S_ = multi_dot((C_.T, self.S, C_))
                     es_, vs_ = eigh(S_)
                     s_ = numpy.sqrt(es_)
                     s_ = numpy.diag(1.0 / s_)
-                    W_ = functools.reduce(numpy.dot, (vs_, s_, vs_.T))
+                    W_ = multi_dot((vs_, s_, vs_.T))
                     self.W = numpy.dot(C_, W_)
 
             if self.unrestricted:
@@ -330,15 +324,15 @@ class MixinLocalize:
             if self.frozen_core:
                 P_core = numpy.eye(W_.shape[0]) - numpy.dot(self.P_core, self.S)
                 C_ = numpy.dot(P_core, W_)
-                Cpop = functools.reduce(numpy.dot, (C_.T, self.S, C_))
+                Cpop = multi_dot((C_.T, self.S, C_))
                 Cpop = numpy.diag(Cpop)
                 no_core_idx = numpy.where(Cpop > 0.55)[0]
                 C_ = C_[:, no_core_idx]
-                S_ = functools.reduce(numpy.dot, (C_.T, self.S, C_))
+                S_ = multi_dot((C_.T, self.S, C_))
                 es_, vs_ = eigh(S_)
                 s_ = numpy.sqrt(es_)
                 s_ = numpy.diag(1.0 / s_)
-                W_ = functools.reduce(numpy.dot, (vs_, s_, vs_.T))
+                W_ = multi_dot((vs_, s_, vs_.T))
                 W_ = numpy.dot(C_, W_)
 
             self.W = get_loc(
@@ -464,15 +458,15 @@ class MixinLocalize:
             if self.frozen_core:
                 P_core = numpy.eye(W_.shape[0]) - numpy.dot(self.P_core, self.S)
                 C_ = numpy.dot(P_core, W_)
-                Cpop = functools.reduce(numpy.dot, (C_.T, self.S, C_))
+                Cpop = multi_dot((C_.T, self.S, C_))
                 Cpop = numpy.diag(Cpop)
                 no_core_idx = numpy.where(Cpop > 0.55)[0]
                 C_ = C_[:, no_core_idx]
-                S_ = functools.reduce(numpy.dot, (C_.T, self.S, C_))
+                S_ = multi_dot((C_.T, self.S, C_))
                 es_, vs_ = eigh(S_)
                 s_ = numpy.sqrt(es_)
                 s_ = numpy.diag(1.0 / s_)
-                W_ = functools.reduce(numpy.dot, (vs_, s_, vs_.T))
+                W_ = multi_dot((vs_, s_, vs_.T))
                 W_ = numpy.dot(C_, W_)
 
             self.W = get_loc(self.mol, W_, "BOYS")

--- a/src/quemb/molbe/pfrag.py
+++ b/src/quemb/molbe/pfrag.py
@@ -1,10 +1,9 @@
 # Author(s): Oinam Romesh Meitei
 
-import functools
-
 import h5py
 import numpy
 import scipy.linalg
+from numpy.linalg import multi_dot
 
 from quemb.molbe.helper import get_eri, get_scfObj, get_veff
 from quemb.molbe.solver import schmidt_decomposition
@@ -154,7 +153,7 @@ class Frags:
             One-electron Hamiltonian matrix.
         """
 
-        h1_tmp = functools.reduce(numpy.dot, (self.TA.T, h1, self.TA))
+        h1_tmp = multi_dot((self.TA.T, h1, self.TA))
         self.h1 = h1_tmp
 
     def cons_fock(self, hf_veff, S, dm, eri_=None):
@@ -202,7 +201,7 @@ class Frags:
         numpy.ndarray
             Projected density matrix.
         """
-        C_ = functools.reduce(numpy.dot, (self.TA.T, S, C[:, ncore : ncore + nocc]))
+        C_ = multi_dot((self.TA.T, S, C[:, ncore : ncore + nocc]))
         P_ = numpy.dot(C_, C_.T)
         nsocc_ = numpy.trace(P_)
         nsocc = int(numpy.round(nsocc_))

--- a/src/quemb/shared/external/lo_helper.py
+++ b/src/quemb/shared/external/lo_helper.py
@@ -5,6 +5,7 @@
 #
 
 import numpy
+from numpy.linalg import eigh, matrix_power, norm
 
 
 def get_symm_mat_pow(A, p, check_symm=True, thresh=1.0e-8):
@@ -14,12 +15,12 @@ def get_symm_mat_pow(A, p, check_symm=True, thresh=1.0e-8):
         For integer p, it calls numpy.linalg.matrix_power
     """
     if abs(int(p) - p) < thresh:
-        return numpy.linalg.matrix_power(A, int(p))
+        return matrix_power(A, int(p))
 
     if check_symm:
-        assert numpy.linalg.norm(A - A.conj().T) < thresh
+        assert norm(A - A.conj().T) < thresh
 
-    e, u = numpy.linalg.eigh(A)
+    e, u = eigh(A)
     Ap = u @ numpy.diag(e**p) @ u.conj().T
 
     return Ap

--- a/src/quemb/shared/external/optqn.py
+++ b/src/quemb/shared/external/optqn.py
@@ -7,6 +7,7 @@
 #
 
 import numpy
+from numpy.linalg import inv, norm
 
 from quemb.molbe.helper import get_eri, get_scfObj
 from quemb.shared import be_var
@@ -30,9 +31,9 @@ def line_search_LF(func, xold, fold, dx, iter_):
     fk = func(xk)
     lcout += 1
 
-    norm_dx = numpy.linalg.norm(dx)
-    norm_fk = numpy.linalg.norm(fk)
-    norm_fold = numpy.linalg.norm(fold)
+    norm_dx = norm(dx)
+    norm_fk = norm(fk)
+    norm_fold = norm(fold)
     alp = 1.0
 
     if norm_fk > rho * norm_fold - sigma2 * norm_dx**2.0:
@@ -43,7 +44,7 @@ def line_search_LF(func, xold, fold, dx, iter_):
             fk = func(xk)
 
             lcout += 1
-            norm_fk = numpy.linalg.norm(fk)
+            norm_fk = norm(fk)
             if lcout == 20:
                 break
 
@@ -81,17 +82,17 @@ def trustRegion(func, xold, fold, Binv, c=0.5):
     microiter = 0  # p
     rho = 0.001  # Threshold for trust region subproblem
     ratio = 0  # Initial r
-    B = numpy.linalg.inv(Binv)  # approx Jacobian
+    B = inv(Binv)  # approx Jacobian
     # dx_gn = - Binv@fold
     dx_gn = -(Binv @ Binv.T) @ B.T @ fold
     dx_sd = -B.T @ fold  # Steepest Descent step
-    t = numpy.linalg.norm(dx_sd) ** 2 / numpy.linalg.norm(B @ dx_sd) ** 2
+    t = norm(dx_sd) ** 2 / norm(B @ dx_sd) ** 2
     prevdx = None
     while ratio < rho or ared < 0.0:
         # Trust Region subproblem
         # minimize (1/2) ||F_k + B_k d||^2 w.r.t. d, s.t. d w/i trust radius
         # to pick the optimal direction using dog leg method
-        if numpy.linalg.norm(dx_gn) < max(1.0, numpy.linalg.norm(xold)) * (
+        if norm(dx_gn) < max(1.0, norm(xold)) * (
             c**microiter
         ):  # Gauss-Newton step within the trust radius
             print(
@@ -101,7 +102,7 @@ def trustRegion(func, xold, fold, Binv, c=0.5):
                 flush=True,
             )
             dx = dx_gn
-        elif t * numpy.linalg.norm(dx_sd) > max(1.0, numpy.linalg.norm(xold)) * (
+        elif t * norm(dx_sd) > max(1.0, norm(xold)) * (
             c**microiter
         ):  # GN step outside, SD step also outside
             print(
@@ -110,7 +111,7 @@ def trustRegion(func, xold, fold, Binv, c=0.5):
                 ": Steepest Descent",
                 flush=True,
             )
-            dx = (c**microiter) / numpy.linalg.norm(dx_sd) * dx_sd
+            dx = (c**microiter) / norm(dx_sd) * dx_sd
         else:  # GN step outside, SD step inside (dog leg step)
             # dx := t*dx_sd + s (dx_gn - t*dx_sd) s.t. ||dx|| = c^p
             print(
@@ -124,23 +125,21 @@ def trustRegion(func, xold, fold, Binv, c=0.5):
             # s is largest value in [0, 1] s.t. ||dx|| \le trust radius
             s = 1
             dx = tdx_sd + s * diff
-            while numpy.linalg.norm(dx) > c**microiter and s > 0:
+            while norm(dx) > c**microiter and s > 0:
                 s -= 0.001
                 dx = tdx_sd + s * diff
         if prevdx is None or not numpy.all(dx == prevdx):
             # Actual Reduction := f(x_k) - f(x_k + dx)
             fnew = func(xold + dx)
-            ared = 0.5 * (numpy.linalg.norm(fold) ** 2 - numpy.linalg.norm(fnew) ** 2)
+            ared = 0.5 * (norm(fold) ** 2 - norm(fnew) ** 2)
             # Predicted Reduction := q(0) - q(dx) where q = (1/2) ||F_k + B_k d||^2
-            pred = 0.5 * (
-                numpy.linalg.norm(fold) ** 2 - numpy.linalg.norm(fold + B @ dx) ** 2
-            )
+            pred = 0.5 * (norm(fold) ** 2 - norm(fold + B @ dx) ** 2)
         # Trust Region convergence criteria
         # r = ared/pred \le rho
         ratio = ared / pred
         microiter += 1
         if prevdx is None or not numpy.all(dx == prevdx) and be_var.PRINT_LEVEL > 2:
-            print("    ||δx||: ", numpy.linalg.norm(dx), flush=True)
+            print("    ||δx||: ", norm(dx), flush=True)
             print(
                 "    Reduction Ratio (Actual / Predicted): ",
                 ared,
@@ -169,7 +168,7 @@ class FrankQN:
         self.f0 = f0
         self.func = func
 
-        self.B0 = numpy.linalg.pinv(J0)
+        self.B0 = pinv(J0)
 
         self.iter_ = 0
 

--- a/src/quemb/shared/external/optqn.py
+++ b/src/quemb/shared/external/optqn.py
@@ -7,7 +7,7 @@
 #
 
 import numpy
-from numpy.linalg import inv, norm
+from numpy.linalg import inv, norm, pinv
 
 from quemb.molbe.helper import get_eri, get_scfObj
 from quemb.shared import be_var

--- a/src/quemb/shared/external/unrestricted_utils.py
+++ b/src/quemb/shared/external/unrestricted_utils.py
@@ -1,10 +1,10 @@
 # Authors: Leah Weisburn, Hongzhou Ye, Henry Tran
 
 import ctypes
-import functools
 
 import h5py
 import numpy
+from numpy.linalg import multi_dot
 from pyscf import ao2mo, lib, scf
 
 
@@ -27,12 +27,8 @@ def make_uhf_obj(fobj_a, fobj_b, frozen=False):
     full_uhf.h1 = (fobj_a.h1, fobj_b.h1)
 
     # Define the HF veff in alpha and beta spin Schmidt spaces
-    full_uhf.veff0_a = functools.reduce(
-        numpy.dot, (fobj_a.TA.T, fobj_a.hf_veff, fobj_a.TA)
-    )
-    full_uhf.veff0_b = functools.reduce(
-        numpy.dot, (fobj_b.TA.T, fobj_b.hf_veff, fobj_b.TA)
-    )
+    full_uhf.veff0_a = multi_dot((fobj_a.TA.T, fobj_a.hf_veff, fobj_a.TA))
+    full_uhf.veff0_b = multi_dot((fobj_b.TA.T, fobj_b.hf_veff, fobj_b.TA))
 
     # Build correct eris
     Vs = uccsd_restore_eris((1, 1, 1), fobj_a, fobj_b)


### PR DESCRIPTION
shortened numpy calls and replaced `functools.reduce(numpy.dot(...` with `multi_dot`;
it's easier to read and faster.