### PR TITLE
Fix: Address remaining ruff errors (cphf_utils & optqn)

### DIFF
--- a/src/quemb/shared/external/cphf_utils.py
+++ b/src/quemb/shared/external/cphf_utils.py
@@ -30,8 +30,6 @@ def get_cphf_A(C, moe, eri, no):
 
 
 def get_cphf_rhs(C, no, v):
-    nao = C.shape[0]
-    nv = nao - no
     Co = C[:, :no]
     Cv = C[:, no:]
 
@@ -39,9 +37,6 @@ def get_cphf_rhs(C, no, v):
 
 
 def cphf_kernel(C, moe, eri, no, v):
-    nao = C.shape[0]
-    nv = nao - no
-
     # build RHS vector, B0
     B0 = get_cphf_rhs(C, no, v)
 
@@ -379,9 +374,6 @@ def get_cpuhf_A(C, moe, eri, no):
 
 
 def get_cpuhf_u(C, moe, eri, no, vpot):
-    n = C[0].shape[0]
-    nv = [n - no[s] for s in [0, 1]]
-    nov = [no[s] * nv[s] for s in [0, 1]]
     Co = [C[s][:, : no[s]] for s in [0, 1]]
     Cv = [C[s][:, no[s] :] for s in [0, 1]]
 
@@ -398,9 +390,6 @@ def get_cpuhf_u(C, moe, eri, no, vpot):
 
 
 def get_cpuhf_u_batch(C, moe, eri, no, vpots):
-    n = C[0].shape[0]
-    nv = [n - no[s] for s in [0, 1]]
-    nov = [no[s] * nv[s] for s in [0, 1]]
     Co = [C[s][:, : no[s]] for s in [0, 1]]
     Cv = [C[s][:, no[s] :] for s in [0, 1]]
 

--- a/src/quemb/shared/external/optqn.py
+++ b/src/quemb/shared/external/optqn.py
@@ -87,6 +87,7 @@ def trustRegion(func, xold, fold, Binv, c=0.5):
     dx_sd = -B.T @ fold  # Steepest Descent step
     t = numpy.linalg.norm(dx_sd) ** 2 / numpy.linalg.norm(B @ dx_sd) ** 2
     prevdx = None
+    ared = 0.0  # Reduction in the objective function; Initialize value to 0
     while ratio < rho or ared < 0.0:
         # Trust Region subproblem
         # minimize (1/2) ||F_k + B_k d||^2 w.r.t. d, s.t. d w/i trust radius
@@ -207,7 +208,6 @@ class FrankQN:
                 dx_i @ self.Binv @ df_i
             )
             self.Binv += tmp__
-            us_tmp = self.Binv @ self.fnew
 
         if trust_region:
             self.xnew, self.fnew = trustRegion(
@@ -216,7 +216,7 @@ class FrankQN:
         else:
             self.us[self.iter_] = self.get_Bnfn(self.iter_)
 
-            alp, self.xnew, self.fnew = line_search_LF(
+            _, self.xnew, self.fnew = line_search_LF(
                 self.func, self.xold, self.fold, -self.us[self.iter_], self.iter_
             )
 
@@ -374,7 +374,7 @@ def get_atbe_Jblock_frag(fobj, res_func):
     Jc = numpy.array(Jc).T
 
     alpha = 0.0
-    for fidx, fval in enumerate(fobj.fsites):
+    for fidx, _ in enumerate(fobj.fsites):
         if not any(fidx in sublist for sublist in fobj.edge_idx):
             alpha += dP_mu[fidx, fidx]
 
@@ -388,7 +388,6 @@ def get_atbe_Jblock_frag(fobj, res_func):
 
 def get_be_error_jacobian_selffrag(self, jac_solver="HF"):
     Jes = [None] * self.Nfrag
-    Jcs = [None] * self.Nfrag
     xes = [None] * self.Nfrag
     xcs = [None] * self.Nfrag
     ys = [None] * self.Nfrag
@@ -401,7 +400,7 @@ def get_be_error_jacobian_selffrag(self, jac_solver="HF"):
     elif jac_solver == "HF":
         res_func = hfres_func
 
-    Jes, Jcs, xes, xcs, ys, alphas, Ncout = get_atbe_Jblock_frag(
+    Jes, _, xes, xcs, ys, alphas, Ncout = get_atbe_Jblock_frag(
         self.Fobjs[0], res_func
     )
 

--- a/src/quemb/shared/external/optqn.py
+++ b/src/quemb/shared/external/optqn.py
@@ -400,9 +400,7 @@ def get_be_error_jacobian_selffrag(self, jac_solver="HF"):
     elif jac_solver == "HF":
         res_func = hfres_func
 
-    Jes, _, xes, xcs, ys, alphas, Ncout = get_atbe_Jblock_frag(
-        self.Fobjs[0], res_func
-    )
+    Jes, _, xes, xcs, ys, alphas, Ncout = get_atbe_Jblock_frag(self.Fobjs[0], res_func)
 
     N_ = Ncout
     J = numpy.zeros((N_ + 1, N_ + 1))


### PR DESCRIPTION
```
src/quemb/shared/external/cphf_utils.py:34:5: F841 Local variable `nv` is assigned to but never used
src/quemb/shared/external/cphf_utils.py:43:5: F841 Local variable `nv` is assigned to but never used
src/quemb/shared/external/cphf_utils.py:384:5: F841 Local variable `nov` is assigned to but never used
src/quemb/shared/external/cphf_utils.py:403:5: F841 Local variable `nov` is assigned to but never used
```
All flagged variables `nv & nov` are the number of virtuals and the number of (occupied + virtuals) that are not used in the code.

```
src/quemb/shared/external/optqn.py:90:26: F821 Undefined name `ared`
src/quemb/shared/external/optqn.py:210:13: F841 Local variable `us_tmp` is assigned to but never used
src/quemb/shared/external/optqn.py:219:13: F841 Local variable `alp` is assigned to but never used
src/quemb/shared/external/optqn.py:404:10: F841 Local variable `Jcs` is assigned to but never used
```
`ared` is a variable later defined in the loop, but not accessed in line 90 due to short-circuiting. For code style compliance, `ared` is now pre-defined with a value.
`us_tmp, alp, Jcs` are safely removed unused variables.

part of #44 