### PR TITLE
fix F841 errors in mbe and ube

### DIFF
--- a/src/quemb/molbe/mbe.py
+++ b/src/quemb/molbe/mbe.py
@@ -555,9 +555,9 @@ class BE(MixinLocalize):
         """
         # Compute the one-particle reduced density matrix (RDM1) and the cumulant
         # (Kumul) in the full basis
-        rdm1f, Kumul, rdm1_lo, rdm2_lo = self.rdm1_fullbasis(
+        rdm1f, Kumul, _, _ = self.rdm1_fullbasis(
             return_lo=True, return_RDM2=False
-        )
+        )  # rdm1f, Kumul, rdm1_lo, rdm2_lo
 
         if not approx_cumulant:
             # Compute the true two-particle reduced density matrix (RDM2) if not using
@@ -891,7 +891,7 @@ class BE(MixinLocalize):
         for fobjs_ in self.Fobjs:
             # Process each fragment
             eri = numpy.array(file_eri.get(fobjs_.dname))
-            dm_init = fobjs_.get_nsocc(self.S, self.C, self.Nocc, ncore=self.ncore)
+            _ = fobjs_.get_nsocc(self.S, self.C, self.Nocc, ncore=self.ncore)
 
             fobjs_.cons_h1(self.hcore)
 
@@ -912,7 +912,7 @@ class BE(MixinLocalize):
             )
 
             if compute_hf:
-                eh1, ecoul, ef = fobjs_.energy_hf(return_e1=True)
+                _, _, _ = fobjs_.energy_hf(return_e1=True)  # eh1, ecoul, ef
                 E_hf += fobjs_.ebe_hf
 
         if not restart:

--- a/src/quemb/molbe/ube.py
+++ b/src/quemb/molbe/ube.py
@@ -182,7 +182,6 @@ class UBE(BE):  # 🍠
             E_hf = 0.0
         EH1 = 0.0
         ECOUL = 0.0
-        EF = 0.0
 
         file_eri = h5py.File(self.eri_file, "w")
         lentmp = len(self.edge_idx)
@@ -308,8 +307,8 @@ class UBE(BE):  # 🍠
             file_eri.create_dataset(fobj_a.dname[1], data=eri_b)
             file_eri.create_dataset(fobj_a.dname[2], data=eri_ab)
 
-            sab = self.C_a @ self.S @ self.C_b
-            dm_init = fobj_a.get_nsocc(self.S, self.C_a, self.Nocc[0], ncore=self.ncore)
+            # sab = self.C_a @ self.S @ self.C_b
+            _ = fobj_a.get_nsocc(self.S, self.C_a, self.Nocc[0], ncore=self.ncore)
 
             fobj_a.cons_h1(self.hcore)
             eri_a = ao2mo.restore(8, eri_a, fobj_a.nao)
@@ -332,7 +331,7 @@ class UBE(BE):  # 🍠
                 ECOUL += ecoul_a
                 E_hf += fobj_a.ebe_hf
 
-            dm_init = fobj_b.get_nsocc(self.S, self.C_b, self.Nocc[1], ncore=self.ncore)
+            _ = fobj_b.get_nsocc(self.S, self.C_b, self.Nocc[1], ncore=self.ncore)
 
             fobj_b.cons_h1(self.hcore)
             eri_b = ao2mo.restore(8, eri_b, fobj_b.nao)


### PR DESCRIPTION
Fixed these issues:
src/quemb/molbe/mbe.py:558:23: F841 Local variable `rdm1_lo` is assigned to but never used
src/quemb/molbe/mbe.py:558:32: F841 Local variable `rdm2_lo` is assigned to but never used
src/quemb/molbe/mbe.py:894:13: F841 Local variable `dm_init` is assigned to but never used
src/quemb/molbe/mbe.py:915:17: F841 Local variable `eh1` is assigned to but never used
src/quemb/molbe/mbe.py:915:22: F841 Local variable `ecoul` is assigned to but never used
src/quemb/molbe/mbe.py:915:29: F841 Local variable `ef` is assigned to but never used
src/quemb/molbe/ube.py:185:9: F841 Local variable `EF` is assigned to but never used
src/quemb/molbe/ube.py:311:13: F841 Local variable `sab` is assigned to but never used
src/quemb/molbe/ube.py:335:13: F841 Local variable `dm_init` is assigned to but never used