### PR TITLE
Enforce stricter checks (`ruff`, `mypy`, and `pylint`)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -19,13 +19,18 @@ if [ "`git diff --check --cached | wc -c`" -gt 0 ]; then
 fi
 
 
-if ! command -v ruff 2>&1 >/dev/null; then
+if ! command -v ruff >/dev/null 2>&1; then
     >&2 echo "Please install ruff via 'pip install ruff'."
     exit 1
 else
-    if ! ruff format --diff `git rev-parse --show-toplevel`; then
+    if ! ruff format --diff `git rev-parse --show-toplevel` >/dev/null 2>&1; then
         >&2 echo "There are problems with PEP8-compliance."
         >&2 echo 'You can check yourself by executing "ruff format --diff `git rev-parse --show-toplevel`"'
+        exit 1
+    fi
+    if ! ruff check `git rev-parse --show-toplevel` >/dev/null 2>&1; then
+        >&2 echo "There are problems in the code."
+        >&2 echo 'You can check yourself by executing "ruff check `git rev-parse --show-toplevel`"'
         exit 1
     fi
 fi

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.9
+    - name: Set up Python 3.10
       uses: actions/setup-python@v5
       with:
-        python-version: "3.9"
+        python-version: "3.10"
         cache: 'pip'
     - name: Install dependencies
       run: |

--- a/.github/workflows/quemb_unittest.yml
+++ b/.github/workflows/quemb_unittest.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.12"]
+        python-version: ["3.13"]
 
 
     steps:
@@ -83,7 +83,7 @@ jobs:
     needs: analysis
     strategy:
       matrix:
-        python-version: ["3.9", "3.12"]
+        python-version: ["3.10", "3.13"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/quemb_unittest.yml
+++ b/.github/workflows/quemb_unittest.yml
@@ -112,7 +112,6 @@ jobs:
         wget https://raw.githubusercontent.com/pyscf/dmrgscf/master/pyscf/dmrgscf/settings.py.example
         mv settings.py.example ${PYSCFHOME}/pyscf/dmrgscf/settings.py
         pip install .
-        echo ${{ github.workspace }} > $(python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")/quemb.pth
 
 
     - name: Test with pytest

--- a/.github/workflows/quemb_unittest.yml
+++ b/.github/workflows/quemb_unittest.yml
@@ -60,7 +60,7 @@ jobs:
     - name: Static analysis with ruff
       # for the moment we want to report always report success
       run: |
-        ruff check . || true
+        ruff check .
 
 
     - name: Static analysis with pylint
@@ -69,7 +69,7 @@ jobs:
       # TODO: if they add it to ruff as well https://github.com/astral-sh/ruff/issues/9103
       #   remove pylint.
       run: |
-        pylint --disable=all --enable=E0401,R0401,E0611 . || true    # for the moment we want to report always report success
+        pylint --disable=all --enable=E0401,R0401,E0611 .    # for the moment we want to report always report success
 
 
     - name: Static analysis with mypy

--- a/.github/workflows/quemb_unittest.yml
+++ b/.github/workflows/quemb_unittest.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.13"]
+        python-version: ["3.10"]
 
 
     steps:

--- a/.github/workflows/quemb_unittest.yml
+++ b/.github/workflows/quemb_unittest.yml
@@ -58,7 +58,6 @@ jobs:
 
 
     - name: Static analysis with ruff
-      # for the moment we want to report always report success
       run: |
         ruff check .
 
@@ -69,7 +68,7 @@ jobs:
       # TODO: if they add it to ruff as well https://github.com/astral-sh/ruff/issues/9103
       #   remove pylint.
       run: |
-        pylint --disable=all --enable=E0401,R0401,E0611 .    # for the moment we want to report always report success
+        pylint --disable=all --enable=E0401,R0401,E0611 .
 
 
     - name: Static analysis with mypy

--- a/.github/workflows/quemb_unittest.yml
+++ b/.github/workflows/quemb_unittest.yml
@@ -74,7 +74,7 @@ jobs:
 
     - name: Static analysis with mypy
       run: |
-        mypy tests/ example/ src/ || true    # for the moment we want to report always report success
+        mypy tests/ example/ src/
 
 
 

--- a/.github/workflows/quemb_unittest.yml
+++ b/.github/workflows/quemb_unittest.yml
@@ -106,6 +106,7 @@ jobs:
 
     - name: Install dependencies
       run: |
+        pip install pytest
         pip install git+https://github.com/pyscf/dmrgscf
         PYSCFHOME=$(pip show pyscf-dmrgscf | grep 'Location' | tr ' ' '\n' | tail -n 1)
         wget https://raw.githubusercontent.com/pyscf/dmrgscf/master/pyscf/dmrgscf/settings.py.example

--- a/.github/workflows/quemb_unittest.yml
+++ b/.github/workflows/quemb_unittest.yml
@@ -48,7 +48,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        pip install --upgrade --upgrade-strategy eager ruff pylint mypy scipy-stubs pytest
+        pip install -r tests/static_analysis_requirements.txt
         pip install .
 
 
@@ -105,7 +105,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        pip install pytest
+        pip install -r tests/test_requirements.txt
         pip install git+https://github.com/pyscf/dmrgscf
         PYSCFHOME=$(pip show pyscf-dmrgscf | grep 'Location' | tr ' ' '\n' | tail -n 1)
         wget https://raw.githubusercontent.com/pyscf/dmrgscf/master/pyscf/dmrgscf/settings.py.example

--- a/.github/workflows/quemb_unittest.yml
+++ b/.github/workflows/quemb_unittest.yml
@@ -48,7 +48,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        pip install --upgrade --upgrade-strategy eager ruff pylint mypy scipy-stubs
+        pip install --upgrade --upgrade-strategy eager ruff pylint mypy scipy-stubs pytest
         pip install .
 
 
@@ -106,8 +106,6 @@ jobs:
 
     - name: Install dependencies
       run: |
-        pip install --upgrade --upgrade-strategy eager pytest
-        if [ -f requirements.txt ]; then pip install --upgrade --upgrade-strategy eager -r requirements.txt; fi
         pip install git+https://github.com/pyscf/dmrgscf
         PYSCFHOME=$(pip show pyscf-dmrgscf | grep 'Location' | tr ' ' '\n' | tail -n 1)
         wget https://raw.githubusercontent.com/pyscf/dmrgscf/master/pyscf/dmrgscf/settings.py.example

--- a/README.md
+++ b/README.md
@@ -29,31 +29,28 @@ processors.
 - PySCF library
 - Numpy
 - Scipy
-- libDMET (required for periodic BE)
-- [Wannier90](https://github.com/wannier-developers/wannier90)<sup>&&</sup> (to use Wannier functions)
+- [libDMET](https://github.com/gkclab/libdmet_preview) (required for periodic BE)
+- [Wannier90](https://github.com/wannier-developers/wannier90)<sup>##</sup> (to use Wannier functions)
 
-<sup>&&</sup>Wannier90 code is interfaced via [libDMET](https://github.com/gkclab/libdmet_preview) in QuEmb</sub>
+<sup>##</sup> `Wannier90` code is optional and only necessary to use Wannier functions in periodic code. </sub>
 
-### Steps
+The required dependencies, with the exception of the optional `Wannier90`,
+are automatically installed by `pip`.
 
-1. Clone the repository:
-   ```bash
-   git clone https://github.com/oimeitei/quemb.git
-   cd quemb
+### Installation
 
-2. Install QuEmb using one of the following approaches:
-    ```bash
-    pip install .
-    ```
-    or simply add `path/to/quemd` to `PYTHONPATH`
-    ```bash
-    export PYTHONPATH=/path/to/quemb:$PYTHONPATH
-    ```
+One can just `pip install` directly from the Github repository:
+```bash
+pip install git+https://https://github.com/troyvvgroup/quemb
+```
 
-    For conda (or virtual environment) installations, after creating your environment, specify the path to mol-be source as a path file, as in:
-    ```bash
-    echo path/to/quemb > $(python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")/quemb.pth
-    ```
+Alternatively one can manually clone and install as in:
+```bash
+git clone https://https://github.com/troyvvgroup/quemb
+cd quemb
+pip install .
+```
+
 
 
 ## Basic Usage

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ processors.
 
 ### Prerequisites
 
-- Python 3.6 or higher
+- Python `>=3.10`
 - PySCF library
 - Numpy
 - Scipy

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 # the additional (!) requirements for building the doc
+# the dependencies of `quemb` itself are given in the setup.py
 sphinx_rtd_theme
 sphinx_autodoc_typehints

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -36,3 +36,8 @@ References
    optimize
    solvers
    misc
+
+
+
+.. role:: bash(code)
+   :language: bash

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -11,7 +11,7 @@ Prerequisites
  * `libDMET <https://github.com/gkclab/libdmet_preview>`__ (required for periodic BE)
  * `Wannier90 <https://github.com/wannier-developers/wannier90>`_ :sup:`##`
 
-| :sup:`##` Wannier90 code is optional and only necessary to use Wannier functions in periodic code.
+| :sup:`##` :code:`Wannier90` code is optional and only necessary to use Wannier functions in periodic code.
 
 The required dependencies, with the exception of the optional :code:`Wannier90`,
 are automatically installed by :bash:`pip`.

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -4,39 +4,34 @@ Installation
 Prerequisites
 -------------
 
- * Python 3.6 or higher
+ * Python >=10 or higher
  * PySCF library
  * Numpy
  * Scipy
- * libDMET :sup:`##` (required for periodic BE)
- * `Wannier90 <https://github.com/wannier-developers/wannier90>`_ :sup:`&&` (to use Wannier functions)
+ * `libDMET <https://github.com/gkclab/libdmet_preview>`__ (required for periodic BE)
+ * `Wannier90 <https://github.com/wannier-developers/wannier90>`_ :sup:`##`
 
-| :sup:`##` The modified version of `libDMET <https://github.com/gkclab/libdmet_preview>`_ available at `here <https://github.com/oimeitei/libdmet_preview>`_ is recommended to run periodic BE using QuEmb.
-| :sup:`&&` Wannier90 code is interfaced via `libDMET <https://github.com/gkclab/libdmet_preview>`_ in QuEmb
+| :sup:`##` Wannier90 code is optional and only necessary to use Wannier functions in periodic code.
+
+The required dependencies, with the exception of the optional :code:`Wannier90`,
+are automatically installed by :bash:`pip`.
 
 
-Obtain the source code
-----------------------
-Clone the Github repository::
+Installation
+-------------
 
-  git clone https://github.com/oimeitei/quemb.git
+One can just :bash:`pip install` directly from the Github repository
 
-pip install
------------
+.. code-block:: bash
 
-::
+  pip install git+https://https://github.com/troyvvgroup/quemb
 
+
+
+Alternatively one can manually clone and install as in
+
+.. code-block:: bash
+
+  git clone https://https://github.com/troyvvgroup/quemb
+  cd quemb
   pip install .
-
-Add to ``PYTHONPATH``
----------------------
-Simply add ``path/to/quemb`` to ``PYTHONPATH``
-::
-
-   export PYTHONPATH=/path/to/quemb:$PYTHONPATH
-
-Conda or virtual environment
-----------------------------
-For conda (or virtual environment) installations, after creating your environment, specify the path to mol-be source as a path file, as in::
-
-  echo path/to/quemb > $(python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")/quemb.pth

--- a/example/__init__.py
+++ b/example/__init__.py
@@ -1,0 +1,3 @@
+# the __init__.py file only exists so that we can
+# have more fine-grained control over which file we want to test how
+# in mypy.

--- a/example/molbe_io_fcidump.py
+++ b/example/molbe_io_fcidump.py
@@ -1,8 +1,9 @@
 # Illustrates how fcidump file containing fragment hamiltonian
 # can be generated using be2fcidump
 
-from quemb.molbe import BE, be_var, fragpart
+from quemb.molbe import BE, fragpart
 from quemb.molbe.misc import be2fcidump, libint2pyscf
+from quemb.shared import be_var
 
 be_var.PRINT_LEVEL = 3
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -3,16 +3,12 @@
     disallow_untyped_defs = True
     check_untyped_defs = True
 
-[mypy-quemb.molbe.*]
+[mypy-quemb.molbe.*,quemb.kbe.*,quemb.shared.external.*]
     disallow_untyped_defs = False
     check_untyped_defs = False
 
 
-[mypy-quemb.kbe.*]
-    disallow_untyped_defs = False
-    check_untyped_defs = False
-
-[mypy-quemb.shared.external.*]
+[mypy-tests.*,example.*]
     disallow_untyped_defs = False
     check_untyped_defs = False
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -3,11 +3,21 @@
     disallow_untyped_defs = True
     check_untyped_defs = True
 
-[mypy-quemb.molbe.*,quemb.kbe.*,quemb.shared.external.*]
+
+# explicitly blacklist files, this means we can easily add in stricter type checks
+# by removing them from the blacklist
+[mypy-quemb.molbe.ube,quemb.molbe.be_parallel,quemb.molbe.autofrag,quemb.molbe.eri_onthefly,quemb.molbe.fragment,quemb.molbe.helper,quemb.molbe.lchain,quemb.molbe.lo,quemb.molbe.mbe,quemb.molbe.misc,quemb.molbe._opt,quemb.molbe.pfrag,quemb.molbe.solver]
     disallow_untyped_defs = False
     check_untyped_defs = False
 
-# explicitly blacklist tests
+[mypy-quemb.kbe.autofrag,quemb.kbe.chain,quemb.kbe.fragment,quemb.kbe.helper,quemb.kbe.__init__,quemb.kbe.lo_k,quemb.kbe.lo,quemb.kbe.misc,quemb.kbe.pbe,quemb.kbe.pfrag,quemb.kbe.solver]
+    disallow_untyped_defs = False
+    check_untyped_defs = False
+
+[mypy-quemb.shared.external.ccsd_rdm,quemb.shared.external.cphf_utils,quemb.shared.external.cpmp2_utils,quemb.shared.external.__init__,quemb.shared.external.jac_utils,quemb.shared.external.lo_helper,quemb.shared.external.optqn,quemb.shared.external.uccsd_eri,quemb.shared.external.unrestricted_utils]
+    disallow_untyped_defs = False
+    check_untyped_defs = False
+
 [mypy-tests.chem_dm_kBE_test,tests.chempot_molBE_test,tests.dm_molBE_test,tests.dmrg_molBE_test,tests.eri_onthefly_test,tests.hf-in-hf_BE_test,tests.kbe_polyacetylene_test,tests.molbe_h8_test,tests.molbe_io_fcidump_test,tests.molbe_octane_get_rdms_test,tests.molbe_oneshot_rbe_hcore_test,tests.molbe_oneshot_rbe_qmmm-fromchk_test,tests.ube-oneshot_test]
     disallow_untyped_defs = False
     check_untyped_defs = False

--- a/mypy.ini
+++ b/mypy.ini
@@ -7,8 +7,12 @@
     disallow_untyped_defs = False
     check_untyped_defs = False
 
+# blacklist tests
+[mypy-tests.chem_dm_kBE_test,tests.chempot_molBE_test,tests.dm_molBE_test,tests.dmrg_molBE_test,tests.eri_onthefly_test,tests.hf-in-hf_BE_test,tests.kbe_polyacetylene_test,tests.molbe_h8_test,tests.molbe_io_fcidump_test,tests.molbe_octane_get_rdms_test,tests.molbe_octane_test,tests.molbe_oneshot_rbe_hcore_test,tests.molbe_oneshot_rbe_qmmm-fromchk_test,tests.ube-oneshot_test]
+    disallow_untyped_defs = False
+    check_untyped_defs = False
 
-[mypy-tests.*,example.*]
+[mypy-example.*]
     disallow_untyped_defs = False
     check_untyped_defs = False
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -7,12 +7,12 @@
     disallow_untyped_defs = False
     check_untyped_defs = False
 
-# blacklist tests
-[mypy-tests.chem_dm_kBE_test,tests.chempot_molBE_test,tests.dm_molBE_test,tests.dmrg_molBE_test,tests.eri_onthefly_test,tests.hf-in-hf_BE_test,tests.kbe_polyacetylene_test,tests.molbe_h8_test,tests.molbe_io_fcidump_test,tests.molbe_octane_get_rdms_test,tests.molbe_octane_test,tests.molbe_oneshot_rbe_hcore_test,tests.molbe_oneshot_rbe_qmmm-fromchk_test,tests.ube-oneshot_test]
+# explicitly blacklist tests
+[mypy-tests.chem_dm_kBE_test,tests.chempot_molBE_test,tests.dm_molBE_test,tests.dmrg_molBE_test,tests.eri_onthefly_test,tests.hf-in-hf_BE_test,tests.kbe_polyacetylene_test,tests.molbe_h8_test,tests.molbe_io_fcidump_test,tests.molbe_octane_get_rdms_test,tests.molbe_oneshot_rbe_hcore_test,tests.molbe_oneshot_rbe_qmmm-fromchk_test,tests.ube-oneshot_test]
     disallow_untyped_defs = False
     check_untyped_defs = False
 
-[mypy-example.*]
+[mypy-example.kbe_polyacetylene,example.molbe_dmrg_block2,example.molbe_h8_chemical_potential,example.molbe_h8_density_matching,example.molbe_hexene_oneshot_uccsd,example.molbe_io_fcidump,example.molbe_octane_get_rdms,example.molbe_octane,example.molbe_oneshot_rbe_hcore,example.molbe_oneshot_rbe_qmmm-fromchk,example.molbe_oneshot_ube_qmmm,example.molbe_ppp]
     disallow_untyped_defs = False
     check_untyped_defs = False
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,0 @@
-pyscf==2.6.2
-pytest==8.3.2
-libdmet @ git+https://github.com/gkclab/libdmet_preview.git
-matplotlib
-attrs
-typing_extensions

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,5 @@ setup(
         "matplotlib",
         "libdmet @ git+https://github.com/gkclab/libdmet_preview.git",
         "attrs",
-        "typing_extensions",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     license="Apache 2.0",
     packages=find_packages("src"),
     package_dir={"": "src"},
-    python_requires=">=3.7",
+    python_requires=">=3.10",
     install_requires=[
         "numpy>=1.22.0",
         "scipy>=1.7.0",

--- a/src/quemb/kbe/lo.py
+++ b/src/quemb/kbe/lo.py
@@ -55,7 +55,7 @@ class Mixin_k_Localize:
             Whether to perform Wannier localization in the IAO space
         """
         if lo_method == "iao" and iao_val_core:
-            raise NotImplementedError("This does not work. Contact Developers.")
+            raise NotImplementedError("iao_val_core and lo_method='iao' not supported.")
 
         if lo_method == "lowdin":
             # Lowdin orthogonalization with k-points

--- a/src/quemb/kbe/pbe.py
+++ b/src/quemb/kbe/pbe.py
@@ -18,7 +18,6 @@ from quemb.molbe._opt import BEOPT
 from quemb.molbe.helper import get_eri, get_scfObj, get_veff
 from quemb.molbe.be_parallel import be_func_parallel
 from quemb.molbe.solver import be_func
-
 from quemb.shared import be_var
 from quemb.shared.external.optqn import (
     get_be_error_jacobian as _ext_get_be_error_jacobian,

--- a/src/quemb/kbe/pbe.py
+++ b/src/quemb/kbe/pbe.py
@@ -15,8 +15,8 @@ from quemb.kbe.lo import Mixin_k_Localize
 from quemb.kbe.misc import print_energy, storePBE
 from quemb.kbe.pfrag import Frags
 from quemb.molbe._opt import BEOPT
-from quemb.molbe.helper import get_eri, get_scfObj, get_veff
 from quemb.molbe.be_parallel import be_func_parallel
+from quemb.molbe.helper import get_eri, get_scfObj, get_veff
 from quemb.molbe.solver import be_func
 from quemb.shared import be_var
 from quemb.shared.external.optqn import (

--- a/src/quemb/kbe/pfrag.py
+++ b/src/quemb/kbe/pfrag.py
@@ -353,49 +353,34 @@ class Frags:
         self,
         u,
         cout=None,
-        return_heff=False,
-        no_chempot=False,
+        do_chempot=True,
         only_chem=False,
     ):
         """Update the effective Hamiltonian for the fragment."""
-
         heff_ = numpy.zeros_like(self.h1)
 
         if cout is None:
             cout = self.udim
 
-        if not no_chempot:
+        if do_chempot:
             for i, fi in enumerate(self.fsites):
                 if not any(i in sublist for sublist in self.edge_idx):
                     heff_[i, i] -= u[-1]
 
         if only_chem:
             self.heff = heff_
-            if return_heff:
-                if cout is None:
-                    return heff_
-                else:
-                    return (cout, heff_)
-            return cout
+            return
+        else:
+            for idx, i in enumerate(self.edge_idx):
+                for j in range(len(i)):
+                    for k in range(len(i)):
+                        if j > k:
+                            continue
+                        heff_[i[j], i[k]] = u[cout]
+                        heff_[i[k], i[j]] = u[cout]
+                        cout += 1
 
-        for idx, i in enumerate(self.edge_idx):
-            for j in range(len(i)):
-                for k in range(len(i)):
-                    if j > k:
-                        continue
-
-                    heff_[i[j], i[k]] = u[cout]
-                    heff_[i[k], i[j]] = u[cout]
-
-                    cout += 1
-
-        self.heff = heff_
-        if return_heff:
-            if cout is None:
-                return heff_
-            else:
-                return (cout, heff_)
-        return cout
+            self.heff = heff_
 
     def set_udim(self, cout):
         for i in self.edge_idx:

--- a/src/quemb/kbe/pfrag.py
+++ b/src/quemb/kbe/pfrag.py
@@ -369,7 +369,6 @@ class Frags:
 
         if only_chem:
             self.heff = heff_
-            return
         else:
             for idx, i in enumerate(self.edge_idx):
                 for j in range(len(i)):

--- a/src/quemb/molbe/pfrag.py
+++ b/src/quemb/molbe/pfrag.py
@@ -268,9 +268,7 @@ class Frags:
         mf_ = None
 
     def update_heff(self, u, cout=None, only_chem=False):
-        """
-        Update the effective Hamiltonian for the fragment.
-        """
+        """Update the effective Hamiltonian for the fragment."""
         heff_ = numpy.zeros_like(self.h1)
 
         if cout is None:

--- a/src/quemb/molbe/solver.py
+++ b/src/quemb/molbe/solver.py
@@ -816,7 +816,7 @@ def solve_block2(mf, nocc, frag_scratch, **solver_kwargs):
         [max_noise, max_noise, max_noise / 10, max_noise / 100, max_noise / 100, 0.0],
     )
     # Other DMRG parameters
-    mc.fcisolver.threads = int(os.environ.get("OMP_NUM_THREADS", 8))
+    mc.fcisolver.threads = int(os.environ.get("OMP_NUM_THREADS", "8"))
     mc.fcisolver.twodot_to_onedot = int(twodot_to_onedot)
     mc.fcisolver.maxIter = int(max_iter)
     mc.fcisolver.block_extra_keyword = list(block_extra_keyword)

--- a/src/quemb/shared/helper.py
+++ b/src/quemb/shared/helper.py
@@ -1,13 +1,10 @@
-from collections.abc import Sequence
-from pathlib import Path
-from typing import Any, Callable, Optional, TypeVar, Dict
-
-from pyscf.tools.cubegen import orbital
-
-from quemb import molbe
-from quemb.shared.manage_scratch import PathLike
+from typing import Any, Callable, Dict, Optional, TypeAlias, TypeVar
 
 Function = TypeVar("Function", bound=Callable)
+
+# A dictionary that is used to pass keyword arguments via unpacking
+# to the next function
+KwargDict: TypeAlias = Dict[str, Any]
 
 
 # Note that we have once Callable and once Function.
@@ -69,39 +66,3 @@ def ncore_(z: int) -> int:
     else:
         raise ValueError("Ncore not computed in helper.ncore(), add it yourself!")
     return nc
-
-
-def write_cube(
-    be_object: molbe.BE,
-    cube_file_path: PathLike,
-    fragment_idx: Optional[Sequence[int]] = None,
-    cubegen_kwargs: Optional[Dict[str, Any]] = None,
-) -> None:
-    """Write cube files of embedding orbitals from a BE object.
-
-    Parameters
-    ----------
-    be_object
-        BE object containing the fragments, each of which contains embedding orbitals.
-    cube_file_path
-        Directory to write the cube files to.
-    fragment_idx
-        Index of the fragments to write the cube files for.
-        If None, write all fragments.
-    cubegen_kwargs
-        Keyword arguments passed to cubegen.orbital.
-    """
-    cube_file_path = Path(cube_file_path)
-    cubegen_kwargs = cubegen_kwargs if cubegen_kwargs else {}
-    if not isinstance(be_object, molbe.BE):
-        raise NotImplementedError("Support for Periodic BE not implemented yet.")
-    if fragment_idx is None:
-        fragment_idx = range(be_object.Nfrag)
-    for idx in fragment_idx:
-        for emb_orb_idx in range(be_object.Fobjs[idx].TA.shape[1]):
-            orbital(
-                be_object.mol,
-                cube_file_path / f"frag_{idx}_orb_{emb_orb_idx}.cube",
-                be_object.Fobjs[idx].TA[:, emb_orb_idx],
-                **cubegen_kwargs,
-            )

--- a/src/quemb/shared/helper.py
+++ b/src/quemb/shared/helper.py
@@ -1,5 +1,6 @@
+from collections.abc import Sequence
 from pathlib import Path
-from typing import Any, Callable, Optional, TypeVar
+from typing import Any, Callable, Optional, TypeVar, Dict
 
 from pyscf.tools.cubegen import orbital
 
@@ -71,26 +72,30 @@ def ncore_(z: int) -> int:
 
 
 def write_cube(
-    be_object: object, cube_file_path: PathLike, fragment_idx: Optional[list], **kwargs
+    be_object: molbe.BE,
+    cube_file_path: PathLike,
+    fragment_idx: Optional[Sequence[int]] = None,
+    cubegen_kwargs: Optional[Dict[str, Any]] = None,
 ) -> None:
     """Write cube files of embedding orbitals from a BE object.
 
     Parameters
     ----------
-    be_object : object
+    be_object
         BE object containing the fragments, each of which contains embedding orbitals.
-    cube_file_path : PathLike
+    cube_file_path
         Directory to write the cube files to.
-    fragment_idx : Optional[list]
+    fragment_idx
         Index of the fragments to write the cube files for.
         If None, write all fragments.
-    kwargs: Any
+    cubegen_kwargs
         Keyword arguments passed to cubegen.orbital.
     """
     cube_file_path = Path(cube_file_path)
+    cubegen_kwargs = cubegen_kwargs if cubegen_kwargs else {}
     if not isinstance(be_object, molbe.BE):
         raise NotImplementedError("Support for Periodic BE not implemented yet.")
-    if not fragment_idx:
+    if fragment_idx is None:
         fragment_idx = range(be_object.Nfrag)
     for idx in fragment_idx:
         for emb_orb_idx in range(be_object.Fobjs[idx].TA.shape[1]):
@@ -98,5 +103,5 @@ def write_cube(
                 be_object.mol,
                 cube_file_path / f"frag_{idx}_orb_{emb_orb_idx}.cube",
                 be_object.Fobjs[idx].TA[:, emb_orb_idx],
-                **kwargs,
+                **cubegen_kwargs,
             )

--- a/src/quemb/shared/io.py
+++ b/src/quemb/shared/io.py
@@ -1,0 +1,45 @@
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Optional
+
+from pyscf.tools.cubegen import orbital
+
+from quemb import molbe
+from quemb.shared.helper import KwargDict
+from quemb.shared.manage_scratch import PathLike
+
+
+def write_cube(
+    be_object: molbe.BE,
+    cube_file_path: PathLike,
+    fragment_idx: Optional[Sequence[int]] = None,
+    cubegen_kwargs: Optional[KwargDict] = None,
+) -> None:
+    """Write cube files of embedding orbitals from a BE object.
+
+    Parameters
+    ----------
+    be_object
+        BE object containing the fragments, each of which contains embedding orbitals.
+    cube_file_path
+        Directory to write the cube files to.
+    fragment_idx
+        Index of the fragments to write the cube files for.
+        If None, write all fragments.
+    cubegen_kwargs
+        Keyword arguments passed to cubegen.orbital.
+    """
+    cube_file_path = Path(cube_file_path)
+    cubegen_kwargs = cubegen_kwargs if cubegen_kwargs else {}
+    if not isinstance(be_object, molbe.BE):
+        raise NotImplementedError("Support for Periodic BE not implemented yet.")
+    if fragment_idx is None:
+        fragment_idx = range(be_object.Nfrag)
+    for idx in fragment_idx:
+        for emb_orb_idx in range(be_object.Fobjs[idx].TA.shape[1]):
+            orbital(
+                be_object.mol,
+                cube_file_path / f"frag_{idx}_orb_{emb_orb_idx}.cube",
+                be_object.Fobjs[idx].TA[:, emb_orb_idx],
+                **cubegen_kwargs,
+            )

--- a/src/quemb/shared/manage_scratch.py
+++ b/src/quemb/shared/manage_scratch.py
@@ -5,12 +5,16 @@ from pathlib import Path
 from shutil import rmtree
 from types import TracebackType
 
-from attr import define
+from attr import define, field
 from typing_extensions import Literal, Optional, TypeAlias, Union
 
 from quemb.shared.be_var import SCRATCH
 
 PathLike: TypeAlias = Union[str, os.PathLike]
+
+
+def _get_absolute_path(pathlike: PathLike) -> Path:
+    return Path(pathlike).resolve()
 
 
 @define(order=False)
@@ -41,13 +45,13 @@ class WorkDir:
     without errors.
     """
 
-    path: Path
-    cleanup_at_end: bool
+    path: Path = field(converter=_get_absolute_path)
+    cleanup_at_end: bool = True
 
-    def __init__(self, scratch_area: PathLike, cleanup_at_end: bool = True) -> None:
-        self.path = Path(scratch_area).resolve()
-        self.cleanup_at_end = cleanup_at_end
-
+    # The __init__ is automatically created
+    # the values `self.path` and `self.cleanup_at_end` are already filled.
+    # we define the __attrs_post_init__ to create the directory
+    def __attrs_post_init__(self) -> None:
         self.path.mkdir(parents=True, exist_ok=True)
         if any(self.path.iterdir()):
             self.cleanup_at_end = False

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,3 @@
+# the __init__.py file only exists so that we can
+# have more fine-grained control over which file we want to test how
+# in mypy.

--- a/tests/chem_dm_kBE_test.py
+++ b/tests/chem_dm_kBE_test.py
@@ -21,7 +21,7 @@ except ImportError:
 
 class Test_kBE_Full(unittest.TestCase):
     @unittest.skipIf(libdmet is None, "Module `libdmet` not imported correctly.")
-    def test_kc2_sto3g_be1_chempot(self):
+    def test_kc2_sto3g_be1_chempot(self) -> None:
         kpt = [1, 1, 1]
         cell = gto.Cell()
 
@@ -46,7 +46,7 @@ class Test_kBE_Full(unittest.TestCase):
             cell, kpt, "be1", "C2 (kBE1)", "autogen", -74.64695833012868, only_chem=True
         )
 
-    def test_kc4_sto3g_be2_density(self):
+    def test_kc4_sto3g_be2_density(self) -> None:
         kpt = [1, 1, 1]
         cell = gto.Cell()
 
@@ -87,7 +87,7 @@ class Test_kBE_Full(unittest.TestCase):
         target,
         delta=1e-4,
         only_chem=True,
-    ):
+    ) -> None:
         kpts = cell.make_kpts(kpt, wrap_around=True)
         mydf = df.GDF(cell, kpts)
         mydf.build()

--- a/tests/molbe_io_fcidump_test.py
+++ b/tests/molbe_io_fcidump_test.py
@@ -15,7 +15,7 @@ from quemb.molbe import BE, fragpart
 from quemb.molbe.misc import be2fcidump, libint2pyscf
 
 
-def prepare_system():
+def prepare_system() -> BE:
     # Read in molecular integrals expressed in libint basis ordering
     # numpy.loadtxt takes care of the input under the hood
     mol, mf = libint2pyscf(
@@ -36,7 +36,7 @@ def prepare_system():
     return oct_be
 
 
-def verify_fcidump_writing(kind_of_MO: str):
+def verify_fcidump_writing(kind_of_MO: str) -> None:
     oct_be = prepare_system()
     tmp_dir = Path(mkdtemp())
     data_dir = Path("data/octane_FCIDUMPs/")
@@ -60,7 +60,7 @@ def verify_fcidump_writing(kind_of_MO: str):
     not os.getenv("QUEMB_DO_KNOWN_TO_FAIL_TESTS") == "true",
     reason="This test is known to fail.",
 )
-def test_embedding():
+def test_embedding() -> None:
     verify_fcidump_writing("embedding")
 
 
@@ -68,7 +68,7 @@ def test_embedding():
     not os.getenv("QUEMB_DO_KNOWN_TO_FAIL_TESTS") == "true",
     reason="This test is known to fail.",
 )
-def test_fragment_mo():
+def test_fragment_mo() -> None:
     verify_fcidump_writing("fragment_mo")
 
 

--- a/tests/molbe_octane_test.py
+++ b/tests/molbe_octane_test.py
@@ -3,6 +3,7 @@
 
 import os
 import tempfile
+from typing import Tuple
 
 import numpy as np
 import pytest
@@ -19,7 +20,7 @@ from quemb.shared.io import write_cube
     not os.getenv("QUEMB_DO_KNOWN_TO_FAIL_TESTS") == "true",
     reason="This test is known to fail.",
 )
-def test_octane_molbe():
+def test_octane_molbe() -> None:
     # Prepare octane molecule
     mol, mf = prepare_octane()
 
@@ -45,7 +46,7 @@ def test_octane_molbe():
     print(f"*** BE2 Correlation Energy Error (%) : {err_:>8.4f} %")
 
 
-def test_cubegen():
+def test_cubegen() -> None:
     # Prepare octane molecule
     mol, mf = prepare_octane()
     # Build fragments
@@ -55,23 +56,21 @@ def test_cubegen():
     mybe.optimize(solver="CCSD", nproc=1, ompnum=1)
     # Write cube file to a temporary location
     with tempfile.TemporaryDirectory() as tmpdir:
-        write_cube(mybe, tmpdir, fragment_idx=[3], resolution=5)
+        write_cube(mybe, tmpdir, fragment_idx=[3], cubegen_kwargs=dict(resolution=5))
         with open(os.path.join(tmpdir, "frag_3_orb_2.cube"), "r") as f:
-            cube_content = f.read()
             cube_content = np.fromstring(
-                "".join(cube_content.split("\n")[2:]), sep=" ", dtype=float
+                "".join(f.read().split("\n")[2:]), sep=" ", dtype=float
             )
         with open("data/octane_frag_3_orb_2.cube", "r") as f:
-            reference_content = f.read()
             reference_content = np.fromstring(
-                "".join(reference_content.split("\n")[2:]), sep=" ", dtype=float
+                "".join(f.read().split("\n")[2:]), sep=" ", dtype=float
             )
         assert np.isclose(
             cube_content, reference_content
         ).all(), "Cube file content does not match reference content."
 
 
-def prepare_octane():
+def prepare_octane() -> Tuple[gto.Mole, scf.hf.RHF]:
     mol = gto.M(
         atom="""
     C   0.4419364699  -0.6201930287   0.0000000000

--- a/tests/molbe_octane_test.py
+++ b/tests/molbe_octane_test.py
@@ -9,7 +9,7 @@ import pytest
 from pyscf import cc, gto, scf
 
 from quemb.molbe import BE, fragpart
-from quemb.shared.helper import write_cube
+from quemb.shared.io import write_cube
 
 # TODO: actually add meaningful tests for energies etc.
 #   At the moment the test fails already for technical reasons.

--- a/tests/scratch_manager_test.py
+++ b/tests/scratch_manager_test.py
@@ -7,7 +7,7 @@ from pytest import raises
 from quemb.shared.manage_scratch import WorkDir
 
 
-def test_already_created():
+def test_already_created() -> None:
     my_tmp = Path(mkdtemp())
     assert my_tmp.exists()
 
@@ -20,7 +20,7 @@ def test_already_created():
         scratch.cleanup()
 
 
-def test_keep_upon_error():
+def test_keep_upon_error() -> None:
     my_tmp = Path(mkdtemp())
     assert my_tmp.exists()
 
@@ -34,7 +34,7 @@ def test_keep_upon_error():
     assert not my_tmp.exists()
 
 
-def test_already_created_non_empty():
+def test_already_created_non_empty() -> None:
     my_tmp = Path(mkdtemp())
 
     assert my_tmp.exists()
@@ -48,7 +48,7 @@ def test_already_created_non_empty():
     assert my_tmp.exists()
 
 
-def test_context_manager():
+def test_context_manager() -> None:
     my_tmp = Path(mkdtemp())
     assert my_tmp.exists()
 
@@ -58,7 +58,7 @@ def test_context_manager():
     assert not my_tmp.exists()
 
 
-def test_creation_user_defined():
+def test_creation_user_defined() -> None:
     test_dir = Path("./scratch_test")
     with WorkDir("./scratch_test") as scratch:
         assert test_dir.exists()
@@ -66,9 +66,9 @@ def test_creation_user_defined():
     assert not test_dir.exists()
 
 
-def test_creation_PID():
+def test_creation_PID() -> None:
     PID = os.getpid()
-    with WorkDir(scratch_area=Path("./scratch_root")) as scratch_root:
+    with WorkDir(path=Path("./scratch_root")) as scratch_root:
         tmp_root = scratch_root.path
         with WorkDir.from_environment(user_defined_root=tmp_root) as dir:
             assert dir.path == tmp_root / f"QuEmb_{PID}"
@@ -76,9 +76,9 @@ def test_creation_PID():
                 assert dir_2.path == tmp_root / f"QuEmb_{PID + 1}"
 
 
-def test_dunder_methods():
+def test_dunder_methods() -> None:
     "Test if we can use an instance of `WorkDir` as if it was a `Path`"
-    with WorkDir(scratch_area=Path("./scratch")) as scratch:
+    with WorkDir(path=Path("./scratch")) as scratch:
         with open(scratch / "test.txt", "w") as f:
             f.write("hello world")
 

--- a/tests/static_analysis_requirements.txt
+++ b/tests/static_analysis_requirements.txt
@@ -1,0 +1,7 @@
+# the additional (!) requirements for performing static analysis of the code
+# the dependencies of `quemb` itself are given in the setup.py
+ruff
+pylint
+mypy
+scipy-stubs
+pytest

--- a/tests/test_requirements.txt
+++ b/tests/test_requirements.txt
@@ -1,0 +1,3 @@
+# the additional (!) requirements for testing the code
+# the dependencies of `quemb` itself are given in the setup.py
+pytest


### PR DESCRIPTION
- fixed a few remaining import issues
- this fixed all current mypy errors
- enforce `ruff check` as part of the test-suite and as part of the commit hook
- enforce a few `pylint` checks as well that cannot be done by `ruff`
- enforce `mypy` as part of the test-suite, legacy files are explicitly black-listed in the `mypy.ini`. This allows to gradually switch on stricter type checks for older files and enforces it for newer ones.
- Explicitly only support python >= 3.10
- updated the requirements file for the test suite
- updated installation instructions
- refactored `kbe.pfrag` `update_heff` to not return anything since it has side-effects