### PR TITLE
Cheaper test variants for Github Actions

### DIFF
--- a/.github/workflows/quemb_unittest.yml
+++ b/.github/workflows/quemb_unittest.yml
@@ -117,6 +117,7 @@ jobs:
       run: |
         cd tests
         QUEMB_SKIP_EXPENSIVE_TESTS=true pytest --durations=0 --durations-min=1.0 --doctest-modules --junitxml=junit/quemb-test-results_${{ matrix.python-version }}.xml
+        # If --duration=0, pytest reports all tests that took longer than what was given with durations-min=[time in seconds]
 
 
     - name: Upload pytest junit results

--- a/.github/workflows/quemb_unittest.yml
+++ b/.github/workflows/quemb_unittest.yml
@@ -116,7 +116,7 @@ jobs:
     - name: Test with pytest
       run: |
         cd tests
-        QUEMB_SKIP_EXPENSIVE_TESTS=true pytest --doctest-modules --junitxml=junit/quemb-test-results_${{ matrix.python-version }}.xml
+        QUEMB_SKIP_EXPENSIVE_TESTS=true pytest --durations=0 --durations-min=1.0 --doctest-modules --junitxml=junit/quemb-test-results_${{ matrix.python-version }}.xml
 
 
     - name: Upload pytest junit results

--- a/src/quemb/kbe/pbe.py
+++ b/src/quemb/kbe/pbe.py
@@ -60,7 +60,7 @@ class BE(Mixin_k_Localize):
         nproc: int = 1,
         ompnum: int = 4,
         iao_val_core: bool = True,
-        exxdiv: str = "ewald",
+        exxdiv: str | None = "ewald",
         kpts: list[list[float]] | None = None,
         cderi: PathLike | None = None,
         iao_wannier: bool = False,

--- a/tests/chempot_molBE_test.py
+++ b/tests/chempot_molBE_test.py
@@ -24,11 +24,13 @@ class TestBE_restricted(unittest.TestCase):
         mol.charge = 0.0
         mol.spin = 0.0
         mol.build()
+        mf = scf.RHF(mol)
+        mf.kernel()
         self.molecular_restricted_test(
-            mol, "be2", "H8 (BE2)", "hchain_simple", -4.30628355, only_chem=True
+            mol, mf, "be2", "H8 (BE2)", "hchain_simple", -4.30628355, only_chem=True
         )
         self.molecular_restricted_test(
-            mol, "be3", "H8 (BE3)", "hchain_simple", -4.30649890, only_chem=True
+            mol, mf, "be3", "H8 (BE3)", "hchain_simple", -4.30649890, only_chem=True
         )
 
     def test_octane_sto3g_ben(self):
@@ -40,18 +42,18 @@ class TestBE_restricted(unittest.TestCase):
         mol.charge = 0.0
         mol.spin = 0.0
         mol.build()
+        mf = scf.RHF(mol)
+        mf.kernel()
         self.molecular_restricted_test(
-            mol, "be2", "Octane (BE2)", "autogen", -310.33471581, only_chem=True
+            mol, mf, "be2", "Octane (BE2)", "autogen", -310.33471581, only_chem=True
         )
         self.molecular_restricted_test(
-            mol, "be3", "Octane (BE3)", "autogen", -310.33447096, only_chem=True
+            mol, mf, "be3", "Octane (BE3)", "autogen", -310.33447096, only_chem=True
         )
 
     def molecular_restricted_test(
-        self, mol, be_type, test_name, frag_type, target, delta=1e-4, only_chem=True
+        self, mol, mf, be_type, test_name, frag_type, target, delta=1e-4, only_chem=True
     ):
-        mf = scf.RHF(mol)
-        mf.kernel()
         fobj = fragpart(frag_type=frag_type, be_type=be_type, mol=mol)
         mybe = BE(mf, fobj)
         mybe.optimize(solver="CCSD", method="QN", only_chem=only_chem)


### PR DESCRIPTION
Try to reduce time for expensive tests
Use `exxdiv=None` before #61
Ask `pytest` to always log expensive tests and time breakdown

7min / tests --> 5.5 min on github actions; save cpu hrs, save the planet :)