### PR TITLE
fixed types

### DIFF
--- a/docs/source/nitpick-exceptions
+++ b/docs/source/nitpick-exceptions
@@ -3,3 +3,4 @@ py:class numpy.float64
 py:class OrderedSet
 py:class ordered_set.OrderedSet
 py:class Number
+py:class AtomIdx

--- a/src/quemb/molbe/chemfrag.py
+++ b/src/quemb/molbe/chemfrag.py
@@ -1,6 +1,5 @@
 from collections import defaultdict
 from collections.abc import Mapping, Sequence
-from numbers import Number
 from typing import Callable, Final, NewType, TypeAlias, cast
 
 import chemcoord as cc
@@ -8,14 +7,12 @@ import numpy as np
 from attr import define
 from chemcoord import Cartesian
 from chemcoord.constants import elements
+from chemcoord.typing import AtomIdx
 from ordered_set import OrderedSet
 from pyscf.gto import Mole
 from typing_extensions import Self
 
 from quemb.shared.typing import T
-
-#: The index of an atom.
-AtomIdx = NewType("AtomIdx", int)
 
 #: The index of a heavy atom, i.e. of a motif.
 #: If hydrogen atoms are not treated differently, then every atom
@@ -76,7 +73,7 @@ def merge_seqs(*seqs: Sequence[T]) -> OrderedSet[T]:
 
 
 # The following can be passed van der Waals radius alternative.
-InVdWRadius: TypeAlias = Number | Callable[[Number], Number] | Mapping[str, Number]
+InVdWRadius: TypeAlias = float | Callable[[float], float] | Mapping[str, float]
 
 
 @define(frozen=True)
@@ -155,7 +152,7 @@ class ConnectivityData:
         else:
             with cc.constants.RestoreElementData():
                 used_vdW_r = elements.loc[:, "atomic_radius_cc"]
-                if isinstance(in_vdW_radius, Number):
+                if isinstance(in_vdW_radius, float):
                     elements.loc[:, "atomic_radius_cc"] = used_vdW_r.map(
                         lambda _: in_vdW_radius
                     )
@@ -163,7 +160,7 @@ class ConnectivityData:
                     elements.loc[:, "atomic_radius_cc"] = used_vdW_r.map(in_vdW_radius)
 
                 elif isinstance(in_vdW_radius, Mapping):
-                    elements.loc[:, "atomic_radius_cc"].update(in_vdW_radius)
+                    elements.loc[:, "atomic_radius_cc"].update(in_vdW_radius)  # type: ignore[arg-type]
                 elif in_vdW_radius is None:
                     # To avoid false-negatives we set all vdW radii to
                     # at least 0.55 Å

--- a/src/quemb/molbe/chemfrag.py
+++ b/src/quemb/molbe/chemfrag.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 from collections.abc import Mapping, Sequence
 from numbers import Real
-from typing import Callable, Final, NewType, TypeAlias, assert_never, cast
+from typing import Callable, Final, NewType, TypeAlias, cast
 
 import chemcoord as cc
 import numpy as np
@@ -11,7 +11,7 @@ from chemcoord.constants import elements
 from chemcoord.typing import AtomIdx
 from ordered_set import OrderedSet
 from pyscf.gto import Mole
-from typing_extensions import Self
+from typing_extensions import Self, assert_never
 
 from quemb.shared.typing import T
 

--- a/tests/static_analysis_requirements.txt
+++ b/tests/static_analysis_requirements.txt
@@ -4,6 +4,7 @@ ruff
 pylint
 mypy
 scipy-stubs
+pandas-stubs
 types-PyYAML
 types-networkx
 pytest


### PR DESCRIPTION
- Use the AtomIdx from chemcoord, which is the one returned by Cartesian.get_bonds()
- Do a few fixes to make pandas happy