### PR TITLE
Clarification for IAOs

### DIFF
--- a/src/quemb/kbe/fragment.py
+++ b/src/quemb/kbe/fragment.py
@@ -29,6 +29,8 @@ class FragPart:
     AO_per_frag: ListOverFrag[list[GlobalAOIdx]]
 
     #: The global orbital indices, including hydrogens, per edge per fragment.
+    #:
+    #: When using IAOs this refers to the valence/small basis.
     AO_per_edge: ListOverFrag[ListOverEdge[list[GlobalAOIdx]]]
 
     #: Reference fragment index per edge:
@@ -45,20 +47,29 @@ class FragPart:
     #: i.e. the list of indices.
     #: This is a list whose entries are sequences containing the relative orbital index
     #  of the center sites within a fragment. Relative is to the own fragment.
+    #:
+    #: When using IAOs this refers to the large basis.
     centerweight_and_relAO_per_center: ListOverFrag[tuple[float, list[RelAOIdx]]]
 
     #: The relative orbital indices, including hydrogens, per edge per fragment.
     #: The index is relative to the own fragment.
+    #:
+    #: When using IAOs this refers to the valence/small basis.
     relAO_per_edge: ListOverFrag[ListOverEdge[list[RelAOIdx]]]
+
     #: The relative atomic orbital indices per edge per fragment.
     #: **Note** for this variable relative means that the AO indices
     #: are relative to the other fragment where the edge is a center.
+    #:
+    #: When using IAOs this refers to the valence/small basis.
     relAO_in_ref_per_edge: ListOverFrag[ListOverEdge[list[RelAOIdxInRef]]]
 
     #: List whose entries are lists containing the relative orbital index of the
     #: origin site within a fragment. Relative is to the own fragment.
     #  Since the origin site is at the beginning
     #: of the motif list for each fragment, this is always a ``list(range(0, n))``
+    #:
+    #: When using IAOs this refers to the valence/small basis.
     relAO_per_origin: ListOverFrag[list[RelAOIdx]]
 
     n_BE: int

--- a/src/quemb/kbe/fragment.py
+++ b/src/quemb/kbe/fragment.py
@@ -46,7 +46,7 @@ class FragPart:
     #: everywhere anyway. We concentrate only on the second part,
     #: i.e. the list of indices.
     #: This is a list whose entries are sequences containing the relative orbital index
-    #  of the center sites within a fragment. Relative is to the own fragment.
+    #:  of the center sites within a fragment. Relative is to the own fragment.
     #:
     #: When using IAOs this refers to the large basis.
     centerweight_and_relAO_per_center: ListOverFrag[tuple[float, list[RelAOIdx]]]
@@ -105,6 +105,10 @@ class FragPart:
         return self.n_frag
 
     def all_centers_are_origins(self) -> bool:
+        if self.iao_valence_basis:
+            raise ValueError("Test is only defined if IAO is not used.")
+            # This is because relAO_per_center uses the large basis
+            # and relAO_per_origin the small/valence basis
         return all(
             relAO_per_center == relAO_per_origin
             for (_, relAO_per_center), relAO_per_origin in zip(

--- a/src/quemb/kbe/fragment.py
+++ b/src/quemb/kbe/fragment.py
@@ -26,6 +26,8 @@ class FragPart:
     frag_type: str
     #: This is a list over fragments  and gives the global orbital indices of all atoms
     #: in the fragment. These are ordered by the atoms in the fragment.
+    #:
+    #: When using IAOs this refers to the large/working basis.
     AO_per_frag: ListOverFrag[list[GlobalAOIdx]]
 
     #: The global orbital indices, including hydrogens, per edge per fragment.
@@ -48,7 +50,7 @@ class FragPart:
     #: This is a list whose entries are sequences containing the relative orbital index
     #: of the center sites within a fragment. Relative is to the own fragment.
     #:
-    #: When using IAOs this refers to the large basis.
+    #: When using IAOs this refers to the large/working basis.
     centerweight_and_relAO_per_center: ListOverFrag[tuple[float, list[RelAOIdx]]]
 
     #: The relative orbital indices, including hydrogens, per edge per fragment.

--- a/src/quemb/kbe/fragment.py
+++ b/src/quemb/kbe/fragment.py
@@ -46,7 +46,7 @@ class FragPart:
     #: everywhere anyway. We concentrate only on the second part,
     #: i.e. the list of indices.
     #: This is a list whose entries are sequences containing the relative orbital index
-    #:  of the center sites within a fragment. Relative is to the own fragment.
+    #: of the center sites within a fragment. Relative is to the own fragment.
     #:
     #: When using IAOs this refers to the large basis.
     centerweight_and_relAO_per_center: ListOverFrag[tuple[float, list[RelAOIdx]]]

--- a/src/quemb/molbe/autofrag.py
+++ b/src/quemb/molbe/autofrag.py
@@ -46,9 +46,13 @@ class FragPart:
 
     #: This is a list over fragments  and gives the global orbital indices of all atoms
     #: in the fragment. These are ordered by the atoms in the fragment.
+    #:
+    #: When using IAOs this refers to the large basis.
     AO_per_frag: ListOverFrag[list[GlobalAOIdx]]
 
     #: The global orbital indices, including hydrogens, per edge per fragment.
+    #:
+    #: When using IAOs this refers to the valence/small basis.
     AO_per_edge: ListOverFrag[ListOverEdge[list[GlobalAOIdx]]]
 
     #: Reference fragment index per edge:
@@ -61,17 +65,23 @@ class FragPart:
 
     #: The relative orbital indices, including hydrogens, per edge per fragment.
     #: The index is relative to the own fragment.
+    #:
+    #: When using IAOs this refers to the valence/small basis.
     relAO_per_edge: ListOverFrag[ListOverEdge[list[RelAOIdx]]]
 
     #: The relative atomic orbital indices per edge per fragment.
     #: **Note** for this variable relative means that the AO indices
     #: are relative to the other fragment where the edge is a center.
+    #:
+    #: When using IAOs this refers to the valence/small basis.
     relAO_in_ref_per_edge: ListOverFrag[ListOverEdge[list[RelAOIdxInRef]]]
 
     #: List whose entries are lists containing the relative orbital index of the
     #: origin site within a fragment. Relative is to the own fragment.
     #  Since the origin site is at the beginning
     #: of the motif list for each fragment, this is always a ``list(range(0, n))``
+    #:
+    #: When using IAOs this refers to the valence/small basis.
     relAO_per_origin: ListOverFrag[list[RelAOIdx]]
 
     #: The first element is a float, the second is the list
@@ -80,6 +90,8 @@ class FragPart:
     #: i.e. the list of indices.
     #: This is a list whose entries are sequences containing the relative orbital index
     #  of the center sites within a fragment. Relative is to the own fragment.
+    #:
+    #: When using IAOs this refers to the large basis.
     centerweight_and_relAO_per_center: ListOverFrag[tuple[float, list[RelAOIdx]]]
 
     #: The motifs/heavy atoms in each fragment, in order.

--- a/src/quemb/molbe/autofrag.py
+++ b/src/quemb/molbe/autofrag.py
@@ -89,7 +89,7 @@ class FragPart:
     #: everywhere anyway. We concentrate only on the second part,
     #: i.e. the list of indices.
     #: This is a list whose entries are sequences containing the relative orbital index
-    #:  of the center sites within a fragment. Relative is to the own fragment.
+    #: of the center sites within a fragment. Relative is to the own fragment.
     #:
     #: When using IAOs this refers to the large basis.
     centerweight_and_relAO_per_center: ListOverFrag[tuple[float, list[RelAOIdx]]]

--- a/src/quemb/molbe/autofrag.py
+++ b/src/quemb/molbe/autofrag.py
@@ -89,7 +89,7 @@ class FragPart:
     #: everywhere anyway. We concentrate only on the second part,
     #: i.e. the list of indices.
     #: This is a list whose entries are sequences containing the relative orbital index
-    #  of the center sites within a fragment. Relative is to the own fragment.
+    #:  of the center sites within a fragment. Relative is to the own fragment.
     #:
     #: When using IAOs this refers to the large basis.
     centerweight_and_relAO_per_center: ListOverFrag[tuple[float, list[RelAOIdx]]]
@@ -146,6 +146,10 @@ class FragPart:
         return self.n_frag
 
     def all_centers_are_origins(self) -> bool:
+        if self.iao_valence_basis:
+            raise ValueError("Test is only defined if IAO is not used.")
+            # This is because relAO_per_center uses the large basis
+            # and relAO_per_origin the small/valence basis
         return all(
             relAO_per_center == relAO_per_origin
             for (_, relAO_per_center), relAO_per_origin in zip(

--- a/src/quemb/molbe/autofrag.py
+++ b/src/quemb/molbe/autofrag.py
@@ -47,7 +47,7 @@ class FragPart:
     #: This is a list over fragments  and gives the global orbital indices of all atoms
     #: in the fragment. These are ordered by the atoms in the fragment.
     #:
-    #: When using IAOs this refers to the large basis.
+    #: When using IAOs this refers to the large/working basis.
     AO_per_frag: ListOverFrag[list[GlobalAOIdx]]
 
     #: The global orbital indices, including hydrogens, per edge per fragment.
@@ -91,7 +91,7 @@ class FragPart:
     #: This is a list whose entries are sequences containing the relative orbital index
     #: of the center sites within a fragment. Relative is to the own fragment.
     #:
-    #: When using IAOs this refers to the large basis.
+    #: When using IAOs this refers to the large/working basis.
     centerweight_and_relAO_per_center: ListOverFrag[tuple[float, list[RelAOIdx]]]
 
     #: The motifs/heavy atoms in each fragment, in order.

--- a/src/quemb/molbe/mbe.py
+++ b/src/quemb/molbe/mbe.py
@@ -689,7 +689,12 @@ class BE(MixinLocalize):
                     "BE1 only works with chemical potential optimization. "
                     "Set only_chem=True"
                 )
-            elif self.fobj.n_BE >= 3 and not self.fobj.all_centers_are_origins():
+            elif (
+                #  The all centers are origins test is not defined for IAOs
+                not self.fobj.iao_valence_basis
+                and self.fobj.n_BE >= 3
+                and not self.fobj.all_centers_are_origins()
+            ):
                 raise ValueError(
                     "BE3 currently does not work with matching conditions, if there "
                     "are centers that are not origins.\n"

--- a/src/quemb/molbe/mbe.py
+++ b/src/quemb/molbe/mbe.py
@@ -690,7 +690,7 @@ class BE(MixinLocalize):
                     "Set only_chem=True"
                 )
             elif (
-                #  The `all_centers_are_origins`` test is not defined for IAOs
+                #  The `all_centers_are_origins` test is not defined for IAOs
                 not self.fobj.iao_valence_basis
                 and self.fobj.n_BE >= 3
                 and not self.fobj.all_centers_are_origins()

--- a/src/quemb/molbe/mbe.py
+++ b/src/quemb/molbe/mbe.py
@@ -690,7 +690,7 @@ class BE(MixinLocalize):
                     "Set only_chem=True"
                 )
             elif (
-                #  The all centers are origins test is not defined for IAOs
+                #  The `all_centers_are_origins`` test is not defined for IAOs
                 not self.fobj.iao_valence_basis
                 and self.fobj.n_BE >= 3
                 and not self.fobj.all_centers_are_origins()


### PR DESCRIPTION
Clarify to which basis, small/valence vs. large, the components of fragpart refer to when using IAOs.
This mismatch invalidates the `all_centers_are_origins` test unfortunately.