### PR TITLE
Fix sphinx-multiversion whitelist

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -91,6 +91,6 @@ html_sidebars = {
 
 # -- Sphinx Multiversion --------------------------------------------------
 # https://holzhaus.github.io/sphinx-multiversion/master/configuration.html#
-smv_tag_whitelist = r"^v\d+\.\d+\.\d+.*$"
+smv_tag_whitelist = r"^v\d+\.\d+\.\d+(-[a-zA-Z0-9\.]+)?$"
 smv_branch_whitelist = r"^main$"
 smv_remote_whitelist = r"^.*$"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -91,6 +91,6 @@ html_sidebars = {
 
 # -- Sphinx Multiversion --------------------------------------------------
 # https://holzhaus.github.io/sphinx-multiversion/master/configuration.html#
-smv_tag_whitelist = r"^v\d+\.\d+\.\d+$"
+smv_tag_whitelist = r"^v\d+\.\d+\.\d+.*$"
 smv_branch_whitelist = r"^main$"
 smv_remote_whitelist = r"^.*$"


### PR DESCRIPTION
because i didn't expect `-alpha` back in the day 😅 

This allows `v0.1.0-alpha` to be recognized, not just `v0.1.0`