### PR TITLE
Order fragments by size (better load-balancing)

### DIFF
--- a/src/quemb/molbe/autofrag.py
+++ b/src/quemb/molbe/autofrag.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Sequence
 from copy import deepcopy
-from typing import Final, Literal, Self, TypeAlias
+from typing import Final, Literal, TypeAlias
 from warnings import warn
 
 import networkx as nx
@@ -13,6 +13,7 @@ from numpy.linalg import norm
 from pyscf import gto
 from pyscf.gto import Mole
 from pyscf.pbc.gto import Cell
+from typing_extensions import Self
 
 from quemb.molbe.helper import are_equal, get_core
 from quemb.molbe.pfrag import Frags

--- a/src/quemb/molbe/autofrag.py
+++ b/src/quemb/molbe/autofrag.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Sequence
 from copy import deepcopy
-from typing import Final, Literal, TypeAlias
+from typing import Final, Literal, Self, TypeAlias
 from warnings import warn
 
 import networkx as nx
@@ -30,6 +30,7 @@ from quemb.shared.typing import (
     PathLike,
     RelAOIdx,
     RelAOIdxInRef,
+    T,
     Vector,
 )
 
@@ -173,6 +174,38 @@ class FragPart:
             weight_and_relAO_per_center=self.weight_and_relAO_per_center_per_frag[I],
             relAO_per_origin=self.relAO_per_origin_per_frag[I],
             unrestricted=unrestricted,
+        )
+
+    def reindex(self, idx: Sequence[int] | Vector) -> Self:
+        def _get_elements(seq: Sequence[T], idx: Sequence[int] | Vector) -> list[T]:
+            return [seq[i] for i in idx]  # type: ignore[index]
+
+        return self.__class__(
+            mol=self.mol,
+            frag_type=self.frag_type,
+            n_BE=self.n_BE,
+            AO_per_frag=_get_elements(self.AO_per_frag, idx),
+            AO_per_edge_per_frag=_get_elements(self.AO_per_edge_per_frag, idx),
+            ref_frag_idx_per_edge_per_frag=_get_elements(
+                self.ref_frag_idx_per_edge_per_frag, idx
+            ),
+            relAO_per_edge_per_frag=_get_elements(self.relAO_per_edge_per_frag, idx),
+            relAO_in_ref_per_edge_per_frag=_get_elements(
+                self.relAO_in_ref_per_edge_per_frag, idx
+            ),
+            relAO_per_origin_per_frag=_get_elements(
+                self.relAO_per_origin_per_frag, idx
+            ),
+            weight_and_relAO_per_center_per_frag=_get_elements(
+                self.weight_and_relAO_per_center_per_frag, idx
+            ),
+            motifs_per_frag=_get_elements(self.motifs_per_frag, idx),
+            origin_per_frag=_get_elements(self.origin_per_frag, idx),
+            H_per_motif=self.H_per_motif,
+            add_center_atom=_get_elements(self.add_center_atom, idx),
+            frozen_core=self.frozen_core,
+            iao_valence_basis=self.iao_valence_basis,
+            iao_valence_only=self.iao_valence_only,
         )
 
 

--- a/src/quemb/molbe/fragment.py
+++ b/src/quemb/molbe/fragment.py
@@ -133,18 +133,13 @@ def fragmentate(
             'It is advised to use "chemgen" instead.'
         )
     if order_by_size:
-        if frag_type == "graphgen":
-            # As soon as motifs_per_frag is defined for graphgen, remove this error.
-            raise NotImplementedError("order_by_size does not work for graphgen yet.")
         result = _order_by_decreasing_size(result)
     return result
 
 
 def _order_by_decreasing_size(fragments: FragPart) -> FragPart:
     """Order by decreasing fragment size"""
-    idx = np.argsort(
-        [-len(motifs) for motifs in fragments.motifs_per_frag], stable=True
-    )
+    idx = np.argsort([-len(motifs) for motifs in fragments.AO_per_frag], stable=True)
     return fragments.reindex(idx)  # type: ignore[arg-type]
 
 

--- a/src/quemb/molbe/fragment.py
+++ b/src/quemb/molbe/fragment.py
@@ -30,7 +30,7 @@ def fragmentate(
     n_BE: int = 2,
     frag_prefix: str = "f",
     frozen_core: bool = False,
-    order_by_size: bool = True,
+    order_by_size: bool = False,
     additional_args: AdditionalArgs | None = None,
 ) -> FragPart:
     """Fragment/partitioning definition

--- a/src/quemb/molbe/fragment.py
+++ b/src/quemb/molbe/fragment.py
@@ -3,6 +3,7 @@
 from typing import TypeAlias
 from warnings import warn
 
+import numpy as np
 from pyscf.gto.mole import Mole
 from typing_extensions import assert_never
 
@@ -29,6 +30,7 @@ def fragmentate(
     n_BE: int = 2,
     frag_prefix: str = "f",
     frozen_core: bool = False,
+    order_by_size: bool = True,
     additional_args: AdditionalArgs | None = None,
 ) -> FragPart:
     """Fragment/partitioning definition
@@ -64,6 +66,9 @@ def fragmentate(
     frag_prefix:
         Prefix to be appended to the fragment datanames. Useful for managing
         fragment scratch directories.
+    order_by_size:
+        Order the fragments by descending size.
+        This can be beneficial for better load-balancing.
     additional_args:
         Additional arguments for different fragmentation functions.
     """
@@ -127,7 +132,17 @@ def fragmentate(
             "Strange number of centers detected. "
             'It is advised to use "chemgen" instead.'
         )
+    if order_by_size:
+        result = _order_by_decreasing_size(result)
     return result
+
+
+def _order_by_decreasing_size(fragments: FragPart) -> FragPart:
+    """Order by decreasing fragment size"""
+    idx = np.argsort(
+        [-len(motifs) for motifs in fragments.motifs_per_frag], stable=True
+    )
+    return fragments.reindex(idx)  # type: ignore[arg-type]
 
 
 def _correct_number_of_centers(fragpart: FragPart) -> bool:

--- a/src/quemb/molbe/fragment.py
+++ b/src/quemb/molbe/fragment.py
@@ -133,6 +133,9 @@ def fragmentate(
             'It is advised to use "chemgen" instead.'
         )
     if order_by_size:
+        if frag_type == "graphgen":
+            # As soon as motifs_per_frag is defined for graphgen, remove this error.
+            raise NotImplementedError("order_by_size does not work for graphgen yet.")
         result = _order_by_decreasing_size(result)
     return result
 

--- a/tests/fragmentation_test.py
+++ b/tests/fragmentation_test.py
@@ -1273,12 +1273,16 @@ class TestBE_Fragmentation(unittest.TestCase):
         mf = scf.RHF(mol)
         mf.kernel()
 
-        fobj = fragmentate(mol, n_BE=2, frag_type="graphgen", print_frags=False)
+        fobj = fragmentate(
+            mol, n_BE=2, frag_type="graphgen", print_frags=False, order_by_size=False
+        )
         mybe = BE(mf, fobj)
 
         assert np.isclose(mf.e_tot, mybe.ebe_hf)
 
-        fobj = fragmentate(mol, n_BE=3, frag_type="graphgen", print_frags=False)
+        fobj = fragmentate(
+            mol, n_BE=3, frag_type="graphgen", print_frags=False, order_by_size=False
+        )
         mybe = BE(mf, fobj)
 
         assert np.isclose(mf.e_tot, mybe.ebe_hf)
@@ -1293,7 +1297,9 @@ class TestBE_Fragmentation(unittest.TestCase):
     ):
         Es = {"target": target}
         for frag_type in ["autogen", "graphgen"]:
-            fobj = fragmentate(frag_type=frag_type, n_BE=n_BE, mol=mf.mol)
+            fobj = fragmentate(
+                frag_type=frag_type, n_BE=n_BE, mol=mf.mol, order_by_size=False
+            )
             mbe = BE(mf, fobj)
             mbe.oneshot(solver="CCSD")
             Es.update({frag_type: mbe.ebe_tot - mbe.ebe_hf})
@@ -1319,7 +1325,9 @@ class TestBE_Fragmentation(unittest.TestCase):
         frag_type,
         target,
     ):
-        fobj = fragmentate(frag_type=frag_type, n_BE=n_BE, mol=mf.mol)
+        fobj = fragmentate(
+            frag_type=frag_type, n_BE=n_BE, mol=mf.mol, order_by_size=False
+        )
         try:
             assert fobj.AO_per_frag == target["AO_per_frag"]
             assert fobj.AO_per_edge_per_frag == target["AO_per_edge_per_frag"]

--- a/tests/test_chemfrag.py
+++ b/tests/test_chemfrag.py
@@ -252,12 +252,15 @@ def test_molecule_with_autocratic_matching():
     mf = scf.RHF(mol)
     mf.kernel()
 
-    fobj = fragmentate(mol, n_BE=2, frag_type="chemgen", print_frags=False)
+    fobj = fragmentate(
+        mol, n_BE=2, frag_type="chemgen", print_frags=False, order_by_size=True
+    )
     mybe = BE(mf, fobj)
-
     assert np.isclose(mf.e_tot, mybe.ebe_hf)
 
-    fobj = fragmentate(mol, n_BE=3, frag_type="chemgen", print_frags=False)
+    fobj = fragmentate(
+        mol, n_BE=3, frag_type="chemgen", print_frags=False, order_by_size=True
+    )
     mybe = BE(mf, fobj)
 
     assert np.isclose(mf.e_tot, mybe.ebe_hf)


### PR DESCRIPTION
Reordering the fragments by decreasing size should improve the load balancing as discussed with @mscho527 and @aalexiu .

As an example:
- Assume that the largest fragment is about 30% larger than the average (it can be worse in realistic systems).
- For CCSD, this size difference corresponds to a runtime increase of roughly a factor of 4.8 (since 1.3**6 = 4.8).
- With 160 fragments and 32 runners, we have about 5 fragments per runner on average.
- If one runner happens to get a large fragment as last fragment, its execution time could be: 4 / 5 * 1 + 1 / 5 * 4.8 = 1.8 times that of a runner with only average-sized fragments; almost a 50% slowdown due to imbalance.

Of course, real-world load balancing will be better than this worst-case scenario.
But we can improve this scenario by starting with large fragments first.