### PR TITLE
Fix: ensure that `rdm1_fullbasis` is side effect free (Address #165)

### DIFF
--- a/src/quemb/molbe/mbe.py
+++ b/src/quemb/molbe/mbe.py
@@ -354,6 +354,7 @@ class BE(MixinLocalize):
         rdm2AO = zeros((nao, nao, nao, nao))
 
         for fobjs in self.Fobjs:
+            rdm2 = fobjs.rdm2__.copy()
             if return_RDM2:
                 # Adjust the one-particle reduced density matrix (RDM1)
                 drdm1 = fobjs.rdm1__.copy()
@@ -366,7 +367,7 @@ class BE(MixinLocalize):
                 ) - 0.5 * einsum(
                     "ij,kl->iklj", drdm1, drdm1, dtype=numpy.float64, optimize=True
                 )
-                fobjs.rdm2__ -= dm_nc
+                rdm2 -= dm_nc
 
             # Generate the projection matrix
             cind = [fobjs.AO_in_frag[i] for i in fobjs.weight_and_relAO_per_center[1]]
@@ -391,7 +392,7 @@ class BE(MixinLocalize):
                 # Transform RDM2 to AO basis
                 rdm2s = einsum(
                     "ijkl,pi,qj,rk,sl->pqrs",
-                    fobjs.rdm2__,
+                    rdm2,
                     *([fobjs.mo_coeffs] * 4),
                     optimize=True,
                 )


### PR DESCRIPTION
Small fix to remove the side effect noted on #165 ; original code acted directly on `fobj.rdm2__`

closes #165 