### PR TITLE
Fix: HF-in-HF error for periodic systems should also account for exxdiv correction

### DIFF
--- a/src/quemb/kbe/pbe.py
+++ b/src/quemb/kbe/pbe.py
@@ -617,7 +617,7 @@ class BE(Mixin_k_Localize):
 
         if compute_hf:
             E_hf /= self.unitcell_nkpt
-            hf_err = self.hf_etot - (E_hf + self.enuc + self.E_core)
+            hf_err = self.hf_etot - (E_hf + self.enuc + self.E_core - self.ek)
 
             self.ebe_hf = E_hf + self.enuc + self.E_core - self.ek
             print(f"HF-in-HF error                 :  {hf_err:>.4e} Ha")


### PR DESCRIPTION
Tiny minor step for #61, it doesn't fully fix #61 yet. This PR just fixes an obvious bit of it. When we use exxdiv correction, it should be included in evaluating the HF-in-HF error. (otherwise, we get large error that is just `self.ek`)