### PR TITLE
Fix: maintain consistency for HF reference (w/ or w/o BE potential)

### DIFF
--- a/src/quemb/molbe/helper.py
+++ b/src/quemb/molbe/helper.py
@@ -219,6 +219,7 @@ def get_core(mol: Mole | Cell) -> tuple[int, list[int], list[int]]:
 
 def get_frag_energy(
     mo_coeffs,
+    #    hf_1rdm,
     nsocc,
     n_frag,
     weight_and_relAO_per_center,
@@ -279,7 +280,7 @@ def get_frag_energy(
     rdm1s_rot = mo_coeffs @ rdm1 @ mo_coeffs.T * 0.5
 
     # Construct the Hartree-Fock 1-RDM
-    hf_1rdm = mo_coeffs[:, :nsocc] @ mo_coeffs[:, :nsocc].conj().T
+    hf_1rdm = mo_coeffs[:, :nsocc] @ mo_coeffs[:, :nsocc].conj().T  #
 
     if use_cumulant:
         # Compute the difference between the rotated RDM1 and the Hartree-Fock 1-RDM


### PR DESCRIPTION
As discussed in subgroup meetings, we want to maintain consistency in the energy expression such that we consistently use HF 1-RDM calculated with BE potential or w/o BE potential as appropriate.