### PR TITLE
Fix: Make molecule unit check case-insensitive

### DIFF
--- a/src/quemb/molbe/mf_interfaces/orca_interface.py
+++ b/src/quemb/molbe/mf_interfaces/orca_interface.py
@@ -164,7 +164,7 @@ try:
     ) -> Calculator:
         orca_work_dir: Final = WorkDir(work_dir / "orca_mf")
         geometry_path: Final = orca_work_dir / "geometry.xyz"
-        if mol.unit != "angstrom":
+        if mol.unit.lower() != "angstrom":
             raise ValueError("mol has to be in Angstrom.")
         Cartesian.from_pyscf(mol).to_xyz(geometry_path)
 


### PR DESCRIPTION
Resolves #205

This pull request addresses an issue where the unit check for pyscf.gto.Mole objects in orca_interface.py was too strict, leading to potential false positive exceptions.

**Description of the Problem**
The existing code checks if the molecule's unit is exactly equal to "angstrom" (lowercase):

if mol.unit != "angstrom":

However, according to the [official pyscf documentation](https://www.google.com/search?q=%5Bhttps://pyscf.org/user/gto.html%23geometry%5D(https://pyscf.org/user/gto.html%23geometry)), any unit string that does not start with 'B' or 'AU' is treated as 'Angstrom'. The documentation itself uses "Angstrom" (with a capital 'A'). The current implementation fails to account for this, incorrectly raising an error for valid pyscf objects.

Description of the Solution
This PR modifies the check to be case-insensitive by converting the mol.unit string to lowercase before comparison:


if mol.unit.lower() != "angstrom":

This change makes the validation more robust and aligns it with the behavior of the pyscf library, ensuring that units like "Angstrom" or "ANGSTROM" are handled correctly.