### PR TITLE
remove unnecessary check for units in orca interface

### DIFF
--- a/src/quemb/molbe/graphfrag.py
+++ b/src/quemb/molbe/graphfrag.py
@@ -250,12 +250,12 @@ class GraphGenUtility:
                 connectionstyle=f"arc3,rad={arc_rads[fdx]}",
             )  # type: ignore[call-overload]
         nx.draw_networkx_labels(
-            G, 
+            G,
             pos,  # type: ignore[arg-type]
-            labels, 
-            font_size=10, 
-            font_color="black", 
-            alpha=1
+            labels,
+            font_size=10,
+            font_color="black",
+            alpha=1,
         )
         plt.tight_layout()
         plt.legend(patches, dnames, loc="upper left", fontsize=8)

--- a/src/quemb/molbe/graphfrag.py
+++ b/src/quemb/molbe/graphfrag.py
@@ -223,7 +223,7 @@ class GraphGenUtility:
             edges = edge_list[fdx]
             nx.draw_networkx_nodes(
                 G,
-                pos,
+                pos,  # type: ignore[arg-type]
                 nodelist=origin_per_frag[fdx],
                 node_color=[color for _ in origin_per_frag[fdx]],  # type: ignore[misc]
                 edgecolors="tab:gray",
@@ -232,7 +232,7 @@ class GraphGenUtility:
             )
             nx.draw_networkx_nodes(
                 G,
-                pos,
+                pos,  # type: ignore[arg-type]
                 nodelist=origin_per_frag[fdx],
                 node_color="whitesmoke",  # type: ignore[arg-type]
                 edgecolors=color,
@@ -248,9 +248,14 @@ class GraphGenUtility:
                 alpha=0.8,
                 edge_color=color,  # type: ignore[arg-type]
                 connectionstyle=f"arc3,rad={arc_rads[fdx]}",
-            )
+            )  # type: ignore[call-overload]
         nx.draw_networkx_labels(
-            G, pos, labels, font_size=10, font_color="black", alpha=1
+            G, 
+            pos,  # type: ignore[arg-type]
+            labels, 
+            font_size=10, 
+            font_color="black", 
+            alpha=1
         )
         plt.tight_layout()
         plt.legend(patches, dnames, loc="upper left", fontsize=8)

--- a/src/quemb/molbe/mf_interfaces/orca_interface.py
+++ b/src/quemb/molbe/mf_interfaces/orca_interface.py
@@ -9,6 +9,8 @@ import numpy as np
 from attrs import define
 from chemcoord import Cartesian
 from pyscf.gto import Mole
+from pyscf.gto.mole import is_au
+from pyscf.lib import param
 from pyscf.scf.hf import RHF
 
 from quemb.molbe.mf_interfaces._pyscf_orbital_order import Orbital
@@ -164,8 +166,9 @@ try:
     ) -> Calculator:
         orca_work_dir: Final = WorkDir(work_dir / "orca_mf")
         geometry_path: Final = orca_work_dir / "geometry.xyz"
-        if mol.unit != "angstrom":
-            raise ValueError("mol has to be in Angstrom.")
+
+        # Call to `Cartesian.from_pyscf` specifies unit = "angstrom" when calling
+        # `atom_coords`, ensuring that the coordinates are converted appropriately.
         Cartesian.from_pyscf(mol).to_xyz(geometry_path)
 
         calc = Calculator(basename="mf_calculation", working_dir=orca_work_dir.path)

--- a/src/quemb/molbe/mf_interfaces/orca_interface.py
+++ b/src/quemb/molbe/mf_interfaces/orca_interface.py
@@ -9,8 +9,6 @@ import numpy as np
 from attrs import define
 from chemcoord import Cartesian
 from pyscf.gto import Mole
-from pyscf.gto.mole import is_au
-from pyscf.lib import param
 from pyscf.scf.hf import RHF
 
 from quemb.molbe.mf_interfaces._pyscf_orbital_order import Orbital


### PR DESCRIPTION
closes #205 

`_prepare_orca_calc` checked the units of `mol` object to make sure that it is in angstroms. This check was case-sensitive (unlike how it was implemented in pyscf).

This check is actually unnecessary, because chemcoord correctly calls `atom_coords(unit = "angstrom")` down the line, converting atom coordinates from Bohr to angstroms if necessary. See below for an example:

```
>>> import pyscf; from chemcoord import Cartesian
>>> mol_ang = pyscf.gto.M(atom = "H 0 0 1; H 0 0 2; H 0 0 3; H 0 0 4", unit = "Angstrom")
>>> mol_b = pyscf.gto.M(atom = "H 0 0 1.889726125; H 0 0 3.77945225; H 0 0 5.669178375; H 0 0 7.5589045", unit = "B")
>>> mol_ang.atom_coords(unit="angstrom")
array([[0., 0., 1.],
       [0., 0., 2.],
       [0., 0., 3.],
       [0., 0., 4.]])
>>> mol_b.atom_coords(unit="angstrom")
array([[0., 0., 1.],
       [0., 0., 2.],
       [0., 0., 3.],
       [0., 0., 4.]])
>>> print(Cartesian.from_pyscf(mol_ang))
  atom    x    y    z
0    H  0.0  0.0  1.0
1    H  0.0  0.0  2.0
2    H  0.0  0.0  3.0
3    H  0.0  0.0  4.0
>>> print(Cartesian.from_pyscf(mol_b))
  atom    x    y    z
0    H  0.0  0.0  1.0
1    H  0.0  0.0  2.0
2    H  0.0  0.0  3.0
3    H  0.0  0.0  4.0
```

also ignores a few `mypy` errors in `graphfrag.py` (which was not modified in this PR) after creating #208 for future fix