### PR TITLE
small fix to the expensive unittest test result artifact file name

### DIFF
--- a/.github/workflows/quemb_unittest.yml
+++ b/.github/workflows/quemb_unittest.yml
@@ -146,5 +146,5 @@ jobs:
       - name: Upload pytest junit results
         uses: actions/upload-artifact@v4
         with:
-          name: quemb-test-results_${{ matrix.python-version }}
+          name: quemb-test-results_${{ matrix.python-version }}_expensive
           path: tests/junit/quemb-test-results_${{ matrix.python-version }}.xml


### PR DESCRIPTION
a tinyyy fix to make sure that the junit test results have different name for the expensive test

fixes the following error:
```
Error: Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run
```