### PR TITLE
Fix workdir cleanup

### DIFF
--- a/src/quemb/molbe/be_parallel.py
+++ b/src/quemb/molbe/be_parallel.py
@@ -187,7 +187,7 @@ def run_solver(
         """
         from pyscf.shciscf import shci  # type: ignore[attr-defined]  # noqa: PLC0415
 
-        frag_scratch = WorkDir(scratch_dir / dname)
+        frag_scratch = scratch_dir.make_subdir(dname)
 
         assert isinstance(solver_args, SHCI_ArgsUser)
         SHCI_args = _SHCI_Args.from_user_input(solver_args)

--- a/src/quemb/molbe/mf_interfaces/orca_interface.py
+++ b/src/quemb/molbe/mf_interfaces/orca_interface.py
@@ -162,7 +162,7 @@ try:
         simple_keywords: Sequence[SimpleKeyword],
         blocks: Sequence[Block],
     ) -> Calculator:
-        orca_work_dir: Final = WorkDir(work_dir / "orca_mf")
+        orca_work_dir: Final = work_dir.make_subdir("orca_mf")
         geometry_path: Final = orca_work_dir / "geometry.xyz"
 
         # Call to `Cartesian.from_pyscf` specifies unit = "angstrom" when calling

--- a/src/quemb/shared/helper.py
+++ b/src/quemb/shared/helper.py
@@ -22,6 +22,7 @@ from quemb.shared.typing import Integral, Matrix, SupportsRichComparison, T
 _Function = TypeVar("_Function", bound=Callable)
 _T_Integral = TypeVar("_T_Integral", bound=Integral)
 _T = TypeVar("_T")
+_R = TypeVar("_R")
 _P = ParamSpec("_P")
 logger = logging.getLogger(__name__)
 
@@ -124,10 +125,6 @@ def delete_multiple_files(*args: Iterable[Path]) -> None:
     for files in args:
         for file in files:
             file.unlink()
-
-
-_P = ParamSpec("_P")
-_R = TypeVar("_R")
 
 
 @define

--- a/src/quemb/shared/manage_scratch.py
+++ b/src/quemb/shared/manage_scratch.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import atexit
 import os
 from functools import partial
 from logging import getLogger
@@ -13,7 +12,7 @@ from attrs import define, field
 from typing_extensions import Self
 
 from quemb.shared.config import settings
-from quemb.shared.helper import clear_directory
+from quemb.shared.helper import clear_directory, register_clean_exit
 from quemb.shared.typing import PathLike
 
 logger = getLogger(__name__)
@@ -101,7 +100,7 @@ class WorkDir:
             clear_directory(self.path)
         if self.cleanup_at_end:
             logger.info(f"Scratch directory {self} registered for automatic cleanup.")
-            atexit.register(partial(self.cleanup, ignore_error=True))
+            register_clean_exit(partial(self.cleanup, ignore_error=True))
 
     def __enter__(self) -> WorkDir:
         return self

--- a/src/quemb/shared/manage_scratch.py
+++ b/src/quemb/shared/manage_scratch.py
@@ -166,6 +166,13 @@ class WorkDir:
                 raise e
         logger.info(f"Scratch directory {self} successfully cleaned up.")
 
+    def make_subdir(self, name: str | PathLike) -> Self:
+        """Create a subdirectory with the same cleanup settings as ``self``."""
+        return self.__class__(
+            self.path / Path(name),
+            cleanup_at_end=self.cleanup_at_end,
+        )
+
     def __fspath__(self) -> str:
         return self.path.__fspath__()
 


### PR DESCRIPTION
- fixed the behaviour of `atexit.register` for our purposes. The function `register_clean_exit` executes a function at exit **only if no exception was raised**.

- Introduce a make_subdir method for the WorkDir where the subdirectory inherits the cleanup settings of the root dir.