### PR TITLE
ensure that one starts from empty orca workdir

### DIFF
--- a/src/quemb/molbe/mf_interfaces/orca_interface.py
+++ b/src/quemb/molbe/mf_interfaces/orca_interface.py
@@ -168,7 +168,7 @@ try:
         simple_keywords: Sequence[SimpleKeyword],
         blocks: Sequence[Block],
     ) -> Calculator:
-        orca_work_dir: Final = work_dir.make_subdir("orca_mf")
+        orca_work_dir: Final = work_dir.make_subdir("orca_mf", ensure_empty=True)
         geometry_path: Final = orca_work_dir / "geometry.xyz"
 
         # Call to `Cartesian.from_pyscf` specifies unit = "angstrom" when calling

--- a/src/quemb/shared/manage_scratch.py
+++ b/src/quemb/shared/manage_scratch.py
@@ -167,7 +167,19 @@ class WorkDir:
         logger.info(f"Scratch directory {self} successfully cleaned up.")
 
     def make_subdir(self, name: str | PathLike, ensure_empty: bool = False) -> Self:
-        """Create a subdirectory with the same cleanup settings as ``self``."""
+        """Create a subdirectory with the same cleanup settings as ``self``.
+
+        If the subdirectory already exists, it is also fine.
+        In this case you can use the :python:`ensure_empty` argument to delete existing
+        files.
+
+        Parameters
+        ----------
+        name:
+            The name of the subdirectory. Its path will be :python:`self.path / name`.
+        ensure_empty:
+            If the directory already exists, ensure that it is empty and delete files.
+        """
         return self.__class__(
             self.path / Path(name),
             cleanup_at_end=self.cleanup_at_end,

--- a/src/quemb/shared/manage_scratch.py
+++ b/src/quemb/shared/manage_scratch.py
@@ -166,11 +166,12 @@ class WorkDir:
                 raise e
         logger.info(f"Scratch directory {self} successfully cleaned up.")
 
-    def make_subdir(self, name: str | PathLike) -> Self:
+    def make_subdir(self, name: str | PathLike, ensure_empty: bool = False) -> Self:
         """Create a subdirectory with the same cleanup settings as ``self``."""
         return self.__class__(
             self.path / Path(name),
             cleanup_at_end=self.cleanup_at_end,
+            ensure_empty=ensure_empty,
         )
 
     def __fspath__(self) -> str:


### PR DESCRIPTION
- expose `ensure_empty` for the make_subdir method
- Ensure that one starts from empty ORCA workdir.


This ensures that one can repeatedly call `get_mf` with the orca backend in one job.
In the case where the user does not want their workdir to be overwritten, they can pass explicitly a WorkDir.