### PR TITLE
Extend timing

### DIFF
--- a/src/quemb/molbe/_cpp/eri_sparse_DF.cpp
+++ b/src/quemb/molbe/_cpp/eri_sparse_DF.cpp
@@ -483,8 +483,7 @@ Matrix eval_via_cholesky(const Matrix &sym_P_pq, const Matrix &L_PQ) noexcept
     // Step 1: Solve L * X = sym_P_pq  →  X = L⁻¹ sym_P_pq
     const Matrix X = L_PQ.triangularView<Eigen::Lower>().solve(sym_P_pq);
     if (LOG_LEVEL <= LogLevel::Info) {
-        cholesky_timer.print("triangular solve "
-                             "completed");
+        cholesky_timer.print("triangular solve completed");
     };
     // Step 2: Return Xᵀ X
     return X.transpose() * X;
@@ -493,6 +492,7 @@ Matrix eval_via_cholesky(const Matrix &sym_P_pq, const Matrix &L_PQ) noexcept
 #ifdef USE_CUDA
 Matrix eval_via_cholesky_cuda(const Matrix &sym_P_pq, const GPU_MatrixHandle &L_PQ)
 {
+    PROFILE_FUNCTION();
     const int n_aux = static_cast<int>(L_PQ.rows());
     const int n_sym_pairs = static_cast<int>(sym_P_pq.cols());
 

--- a/src/quemb/molbe/autofrag.py
+++ b/src/quemb/molbe/autofrag.py
@@ -265,10 +265,10 @@ def autogen(
     print_frags : bool, optional
         Whether to print out the list of resulting fragments. Defaults to True.
     """
-    if not (1 <= n_BE <= 4):
-        raise ValueError(
-            "n_BE > 4 is not supported (and n_BE < 1 does not make sense)."
-        )
+    if n_BE > 4:
+        raise ValueError("n_BE > 4 not supported, use 'chemgen' or 'graphgen' instead.")
+    if n_BE < 1:
+        raise ValueError("n_BE < 1 does not make sense.")
 
     if iao_valence_basis is not None:
         warn(

--- a/src/quemb/molbe/autofrag.py
+++ b/src/quemb/molbe/autofrag.py
@@ -265,6 +265,10 @@ def autogen(
     print_frags : bool, optional
         Whether to print out the list of resulting fragments. Defaults to True.
     """
+    if not (1 <= n_BE <= 4):
+        raise ValueError(
+            "n_BE > 4 is not supported (and n_BE < 1 does not make sense)."
+        )
 
     if iao_valence_basis is not None:
         warn(


### PR DESCRIPTION
- Extended the timing to the ERI transform GPU code. The more fine-grained timings spotted a bottleneck when filling the lower triangle of a matrix. Wrote it both nicer and more performant now.

- Added an additional check to `autogen` that prevents an ill-defined usage for n_BE > 4. (relevant for #204)