### PR TITLE
expose chemgen info

### DIFF
--- a/src/quemb/molbe/chemfrag.py
+++ b/src/quemb/molbe/chemfrag.py
@@ -1042,6 +1042,11 @@ class PurelyStructureFragmented(Generic[_T_chemsystem]):
         return len(self.conn_data.motifs) != sum(len(x) for x in self.centers_per_frag)
 
 
+@define(kw_only=True)
+class ChemFragPart(FragPart):
+    fragmented: Final[Fragmented]
+
+
 @define(frozen=True, kw_only=True)
 class Fragmented(Generic[_T_chemsystem]):
     """Contains the whole BE fragmentation information, including AO indices.
@@ -1332,8 +1337,8 @@ class Fragmented(Generic[_T_chemsystem]):
         """The number of fragments."""
         return len(self.AO_per_frag)
 
-    def _get_FragPart_no_iao(self) -> FragPart:
-        """Transform into a :class:`quemb.molbe.autofrag.FragPart`
+    def _get_FragPart_no_iao(self) -> ChemFragPart:
+        """Transform into a :class:`quemb.molbe.chemfrag.ChemFragPart`
         for further use in quemb.
 
         Matches the output of :func:`quemb.molbe.autofrag.autogen`.
@@ -1359,7 +1364,7 @@ class Fragmented(Generic[_T_chemsystem]):
         origin_per_frag = list(union_of_seqs(*self.frag_structure.origin_per_frag))
         assert len(origin_per_frag) == len(self)
 
-        return FragPart(
+        return ChemFragPart(
             mol=self.mol,
             frag_type="chemgen",
             n_BE=self.frag_structure.n_BE,
@@ -1392,6 +1397,7 @@ class Fragmented(Generic[_T_chemsystem]):
             frozen_core=self.frozen_core,
             iao_valence_basis=None,
             iao_valence_only=False,
+            fragmented=self,
         )
 
     def _get_FragPart_with_iao(self, wrong_iao_indexing: bool) -> FragPart:

--- a/src/quemb/molbe/fragment.py
+++ b/src/quemb/molbe/fragment.py
@@ -13,7 +13,7 @@ from quemb.molbe.autofrag import (
     FragType,
     autogen,
 )
-from quemb.molbe.chemfrag import ChemGenArgs, chemgen
+from quemb.molbe.chemfrag import ChemFragPart, ChemGenArgs, chemgen
 from quemb.molbe.graphfrag import GraphGenArgs, graphgen
 
 AdditionalArgs: TypeAlias = AutogenArgs | ChemGenArgs | GraphGenArgs
@@ -31,7 +31,7 @@ def fragmentate(
     frozen_core: bool = False,
     order_by_size: bool = False,
     additional_args: AdditionalArgs | None = None,
-) -> FragPart:
+) -> FragPart | ChemFragPart:
     """Fragment/partitioning definition
 
     Interfaces the fragmentation functions in MolBE. It defines


### PR DESCRIPTION
Expose additional chemgen info for downstream code.

This allows to specialize via:
```python
if isinstance(x, ChemFragPart):
    x.fragmented....
```
and use the additional available info.