### PR TITLE
Updating fragment SCF routine

### DIFF
--- a/src/quemb/molbe/helper.py
+++ b/src/quemb/molbe/helper.py
@@ -104,7 +104,7 @@ def get_scfObj(
 
     Returns
     -------
-    mf_f :
+    mf_f : pyscf.scf.hf.RHF
         The SCF object after running the Hartree-Fock calculation.
     """
     # from 40-customizing_hamiltonian.py in pyscf examples


### PR DESCRIPTION
Adding several unexposed fragment SCF options.

The most dramatic change here is the change of the backup SCF algorithm from level shifting + damping to SOSCF. In our experience, SOSCF is much more robust than either of the other options in PySCF across different HF types.

Two keywords are also added:
`max_cycles`: allowing for a controllable number of maximum SCF cycles before switching SCF algorithms. For certain applications (like CNOs), we may not need a tightly-converged result here.
`skip_soscf`: for the same use case, skipping the second convergence algorithm, even if the fragment SCF is unconverged after DIIS.

There are additional changes that _could_ be made here, if desired, including the introduction of an exposed fragment SCFArgs with more fine knobs. For now, we just raise warnings if a fragment SCF fails after some number of iterations and continue, but we could adjust this behavior. If there is a desire for such a behavior (or others), please let me know! 