### PR TITLE
Add ability to selectively initialize fragment

### DIFF
--- a/src/quemb/molbe/chemfrag.py
+++ b/src/quemb/molbe/chemfrag.py
@@ -1209,8 +1209,10 @@ class Fragmented(Generic[_T_chemsystem]):
     #: The molecule with the valence/minimal basis, if we use IAO.
     iao_valence_mol: _T_chemsystem | None = field(
         eq=cmp_using(
-            lambda x, y: (x is None and y is None)
-            or (x is not None and y is not None and are_equal(x, y))
+            lambda x, y: (
+                (x is None and y is None)
+                or (x is not None and y is not None and are_equal(x, y))
+            )
         )
     )
 

--- a/src/quemb/molbe/eri_sparse_DF.py
+++ b/src/quemb/molbe/eri_sparse_DF.py
@@ -189,7 +189,7 @@ def get_atom_per_MO(
 ) -> dict[MOIdx, set[AtomIdx]]:
     n_MO = TA.shape[-1]
     large_enough = {
-        i_MO: (TA[:, i_MO] ** 2 > epsilon).nonzero()[0]
+        i_MO: cast(Sequence[AOIdx], (TA[:, i_MO] ** 2 > epsilon).nonzero()[0])
         for i_MO in cast(Sequence[MOIdx], range(n_MO))
     }
     return {
@@ -607,7 +607,7 @@ def _run_sparse_df_driver(
     mol: Final[Mole] = mf.mol
     auxmol: Final[Mole] = make_auxmol(mol, auxbasis=auxbasis)
 
-    S_abs = approx_S_abs(mol)
+    S_abs: Final[Matrix[np.floating]] = approx_S_abs(mol)
 
     PQ: Final = auxmol.intor("int2c2e")
     lowtri: Final[LPQ] = build_lowtri_PQ(cholesky(PQ, lower=True))

--- a/src/quemb/molbe/graphfrag.py
+++ b/src/quemb/molbe/graphfrag.py
@@ -536,9 +536,7 @@ def graphgen(
                                 adjacency_graph,
                                 source=adx,
                                 target=bdx,
-                                weight=lambda a, b, _: (
-                                    adjacency_graph[a][b]["weight"]
-                                ),
+                                weight=lambda a, b, _: adjacency_graph[a][b]["weight"],
                                 method="dijkstra",
                             )
                         }

--- a/src/quemb/molbe/mbe.py
+++ b/src/quemb/molbe/mbe.py
@@ -304,7 +304,7 @@ class BE:
             )
 
         initialize_fragment_idx = (
-            range(fobj.n_frag)
+            list(range(fobj.n_frag))
             if initialize_fragment_idx is None
             else initialize_fragment_idx
         )

--- a/src/quemb/molbe/mbe.py
+++ b/src/quemb/molbe/mbe.py
@@ -152,6 +152,7 @@ class BE:
         MO_coeff_epsilon: float = 1e-5,
         AO_coeff_epsilon: float = 1e-10,
         re_eval_HF: bool = False,
+        initialize_fragment_idx: list[int] | None = None,
     ) -> None:
         r"""
         Constructor for BE object.
@@ -230,6 +231,12 @@ class BE:
             one global Fock matrix in the traditional sense, such as ORCA's RIJCOSX,
             then the energy obtained by building the Fock matrix from the
             MO coefficients can actually differ from the reported HF energy.
+        initialize_fragment_idx:
+            Takes in a list of fragment indices to initialize.
+            If None (default), all fragments are initialized.
+            If a list of indices is provided, we perform ERI transformations
+            only for the specified fragments.
+            The selective initialization faciliates projects that extend quemb.
         """
         if restart:
             # Load previous calculation data from restart file
@@ -284,6 +291,25 @@ class BE:
 
         self.lo_bath_post_schmidt: Literal["cholesky", "ER", "PM", "boys"] | None = (
             lo_bath_post_schmidt
+        )
+
+        # Check validity of the initialize_fragment_idx input
+        if initialize_fragment_idx is not None and int_transform not in [
+            "in-core",
+            "out-core-DF",
+        ]:
+            raise NotImplementedError(
+                "Selective fragment initialization is only implemented for 'in-core' "
+                "and 'out-core-DF' integral transformations."
+            )
+
+        initialize_fragment_idx = (
+            range(fobj.n_frag)
+            if initialize_fragment_idx is None
+            else initialize_fragment_idx
+        )
+        assert all(idx in range(fobj.n_frag) for idx in initialize_fragment_idx), (
+            "All indices in initialize_fragment_idx must be valid fragment indices."
         )
 
         self.ebe_hf = 0.0
@@ -375,9 +401,19 @@ class BE:
 
         if not restart:
             # Initialize fragments and perform initial calculations
-            self.initialize(mf._eri, restart=False, int_transform=int_transform)
+            self.initialize(
+                mf._eri,
+                restart=False,
+                int_transform=int_transform,
+                initialize_fragment_idx=initialize_fragment_idx,
+            )
         else:
-            self.initialize(None, restart=True, int_transform=int_transform)
+            self.initialize(
+                None,
+                restart=True,
+                int_transform=int_transform,
+                initialize_fragment_idx=initialize_fragment_idx,
+            )
 
     def save(self, save_file: PathLike = "storebe.pk") -> None:
         """
@@ -994,6 +1030,7 @@ class BE:
         int_transform: IntTransforms,
         eri_: Matrix[np.floating] | None,
         file_eri: h5py.File,
+        initialize_fragment_idx: list[int],
     ):
         """
         Transforms electron repulsion integrals (ERIs) for each fragment
@@ -1017,10 +1054,11 @@ class BE:
         int_transform : The transformation strategy.
         eri_ : The ERIs for the molecule.
         file_eri : The output file where transformed ERIs are stored.
+        initialize_fragment_idx : List of fragment indices to initialize.
         """
         if int_transform == "in-core":
             ensure(eri_ is not None, "ERIs have to be available in memory.")
-            for I in range(self.fobj.n_frag):
+            for I in initialize_fragment_idx:
                 eri = ao2mo.incore.full(eri_, self.Fobjs[I].TA, compact=True)
                 file_eri.create_dataset(self.Fobjs[I].dname, data=eri)
         elif int_transform == "out-core-DF":
@@ -1028,7 +1066,7 @@ class BE:
                 hasattr(self.mf, "with_df") and self.mf.with_df is not None,
                 "Pyscf mean field object has to support `with_df`.",
             )
-            for I in range(self.fobj.n_frag):
+            for I in initialize_fragment_idx:
                 eri = self.mf.with_df.ao2mo(self.Fobjs[I].TA, compact=True)
                 file_eri.create_dataset(self.Fobjs[I].dname, data=eri)
         elif int_transform == "int-direct-DF":
@@ -1159,6 +1197,7 @@ class BE:
         *,
         restart: bool,
         int_transform: IntTransforms,
+        initialize_fragment_idx: list[int],
     ) -> None:
         """
         Initialize the Bootstrap Embedding calculation.
@@ -1171,6 +1210,8 @@ class BE:
             Whether to restart from a previous calculation, by default False.
         int_transfrom :
             Which integral transformation to perform.
+        initialize_fragment_idx :
+            Perform ERI transformations for the fragments with these indices.
         """
         for I in range(self.fobj.n_frag):
             fobjs_ = self.fobj.to_Frags(I, eri_file=self.eri_file)
@@ -1194,7 +1235,7 @@ class BE:
 
         if not restart:
             file_eri = h5py.File(self.eri_file, "w")
-            self._eri_transform(int_transform, eri_, file_eri)
+            self._eri_transform(int_transform, eri_, file_eri, initialize_fragment_idx)
 
         self._initialize_fragments(file_eri, restart)
 

--- a/src/quemb/shared/helper.py
+++ b/src/quemb/shared/helper.py
@@ -176,7 +176,7 @@ class Timer:
     """Simple class to time code execution"""
 
     message: str = "Elapsed time"
-    start: float = field(init=False, factory=lambda: time.perf_counter())
+    start: float = field(init=False, factory=time.perf_counter)
 
     def __attrs_post_init__(self) -> None:
         logger.info(f"Timer with message '{self.message}' started.")

--- a/tests/test_mf_interface.py
+++ b/tests/test_mf_interface.py
@@ -396,9 +396,7 @@ def test_pyscf_parsing() -> None:
 
     assert computed == expected
 
-    computed_idx = argsort(
-        mol.ao_labels(), key=lambda label: Orbital.from_pyscf_label(label)
-    )
+    computed_idx = argsort(mol.ao_labels(), key=Orbital.from_pyscf_label)
 
     # Surprise, Surprise 🥳
     # PYSCF is ordered by PYSCF convention


### PR DESCRIPTION
This adds an option to specify which fragment to perform ERI transformation when BE object is created. This functionality is useful for a number of projects going on in the group, i.e., gradients & ibc

For now, I am adding the functionality only for in-core and out-core-DF. Future PR should add them for other integral transformation routines as necessary.