### PR TITLE
add periodic integral direct CCGDF

### DIFF
--- a/src/quemb/kbe/eri_onthefly.py
+++ b/src/quemb/kbe/eri_onthefly.py
@@ -150,7 +150,7 @@ def integral_direct_DF(mf, Fobjs, file_eri, auxbasis=None):
             logger.debug("(μν|G) -> (ij|G) for frag #%d", fragidx)
             Gqi = ints @ Fobjs[fragidx].TA
             Giq = Gqi.transpose(0, 2, 1)
-            pqG_frag[fragidx][start:end, :, :] = Giq @ Fobjs[fragidx].TA
+            pqG_frag[fragidx][start:end, :, :] = Giq @ Fobjs[fragidx].TA.conj()
 
     end = 0
     blockranges = [
@@ -175,7 +175,7 @@ def integral_direct_DF(mf, Fobjs, file_eri, auxbasis=None):
             logger.debug("(μν|P) -> (ij|P) for frag #%d", fragidx)
             Lqi = ints @ Fobjs[fragidx].TA
             Liq = Lqi.transpose(0, 2, 1)
-            Lij = Liq @ Fobjs[fragidx].TA
+            Lij = Liq @ Fobjs[fragidx].TA.conj()
 
             # Add in contributions from the reciprocal space
             pqL_frag[fragidx][start:end, :, :] = Lij + (

--- a/src/quemb/kbe/eri_onthefly.py
+++ b/src/quemb/kbe/eri_onthefly.py
@@ -1,6 +1,6 @@
 import logging
 
-from numpy import complex128, sqrt, zeros
+from numpy import abs, complex128, sqrt, zeros
 from pyscf import lib
 from pyscf.ao2mo.addons import restore
 from pyscf.pbc.df.df import make_auxcell, make_modrho_basis
@@ -42,7 +42,7 @@ def _j2c_cholesky_or_eig(j2c):
             "decomposition."
         )
         d, V = eigh(j2c)  # V d V.T = (P|Q)
-        return V[:, d > 1e-14] / sqrt(d[d > 1e-14]) @ V[:, d > 1e-14].T, False
+        return V[:, d > 1e-14] / sqrt(d[d > 1e-14]) @ V[:, d > 1e-14].conj().T, False
 
 
 def integral_direct_DF(mf, Fobjs, file_eri, auxbasis=None):
@@ -163,7 +163,7 @@ def integral_direct_DF(mf, Fobjs, file_eri, auxbasis=None):
         for x, y in lib.prange(
             0,
             len(Gv),
-            block_step_size(len(Fobjs), len(Gv), mf.cell.nao, dtype=complex128),
+            block_step_size(len(Fobjs), len(Gv), mf.cell.nao, datatype=complex128),
         )
     ]
 
@@ -224,7 +224,7 @@ def integral_direct_DF(mf, Fobjs, file_eri, auxbasis=None):
             bb = j2c @ b
         logger.debug("Finished obtaining B_{ij}^{L} for frag #%d", fragidx)
         eri_nosym = bb.T @ bb
-        if (eri_nosym.imag > 1e-6).any():
+        if (abs(eri_nosym.imag) > 1e-6).any():
             raise ValueError(
                 f"Imaginary part of ERI is larger than 1e-6 for frag #{fragidx}."
             )

--- a/src/quemb/kbe/eri_onthefly.py
+++ b/src/quemb/kbe/eri_onthefly.py
@@ -101,9 +101,12 @@ def integral_direct_DF(mf, Fobjs, file_eri, auxbasis=None):
             shls_slice=shls_slice,
         )  # Remove the part calculated in the reciprocal space to avoid double counting
 
+        assert ints.shape[0] == mf.cell.nao**2
+
         logger.debug("Finish calculating (μν|P) for range %s", aux_range)
 
-        return ints.reshape(-1, mf.cell.nao, mf.cell.nao)  # TODO: ij pair to i, j
+        # (nao*nao, naux) -> (naux, nao, nao)
+        return ints.T.reshape(-1, mf.cell.nao, mf.cell.nao)
 
     def calculate_Gpq_pbcFS(pw_range):
         r"""Internal function to calculate the 3-center integrals for a given range of
@@ -111,7 +114,7 @@ def integral_direct_DF(mf, Fobjs, file_eri, auxbasis=None):
 
         Parameters
         ----------
-        aux_range : tuple of int
+        pw_range : tuple of int
             (start index, end index) of the plane wave basis functions
             to calculate the 3-center integrals, i.e.
             (:math:`(pq|G)`) with G :math:`\in [start, end)` is returned
@@ -156,6 +159,10 @@ def integral_direct_DF(mf, Fobjs, file_eri, auxbasis=None):
     )  # (P|Q) accounting for periodic images and G=0 divergence
     # TODO: reexamine kpoint, as (P|Q) depends on momentum transfer
     j2c, ischol = _j2c_cholesky_or_eig(j2c[0])  # TODO: kpt
+    # If ischol, j2c is triangular matrix from Cholesky decomposition
+    # Otherwise, this is (P|Q)^(-1/2) from eigendecomposition
+    # We intentionally reuse j2c name because this variable has the memory scaling
+    # of (N_AO^2), which is how this ERI routine scales memory-wise.
 
     end = 0
     Granges = [

--- a/src/quemb/kbe/eri_onthefly.py
+++ b/src/quemb/kbe/eri_onthefly.py
@@ -1,6 +1,6 @@
 import logging
 
-from numpy import complex128, zeros
+from numpy import complex128, sqrt, zeros
 from pyscf import lib
 from pyscf.ao2mo.addons import restore
 from pyscf.pbc.df.df import make_auxcell, make_modrho_basis
@@ -8,11 +8,41 @@ from pyscf.pbc.df.ft_ao import ft_ao, ft_aopair
 from pyscf.pbc.df.gdf_builder import _CCGDFBuilder
 from pyscf.pbc.df.incore import aux_e2
 from pyscf.pbc.tools import get_coulG
-from scipy.linalg import cholesky, solve_triangular
+from scipy.linalg import LinAlgError, cholesky, eigh, solve_triangular
 
 from quemb.molbe.eri_onthefly import block_step_size
 
 logger = logging.getLogger(__name__)
+
+
+def _j2c_cholesky_or_eig(j2c):
+    r"""PBC DF Metric (P|Q) can be non-positive-definite.
+    In this case, we want to fallback to eigenvalue decomposition.
+
+    Parameters
+    ----------
+    j2c : ndarray
+        (P|Q) metric matrix
+
+    Returns
+    -------
+    j2c : ndarray
+        If Cholesky was successful, lower triangle L such that L @ L.T = (P|Q)
+        If fallback to eigenvalue decomposition, V d^{-1/2} V.T
+    ischol : bool
+        Whether Cholesky decomposition was successful or not.
+    """
+    try:
+        low = cholesky(j2c, lower=True)
+        logger.debug("(P|Q) positive definite. Cholesky decomposition successful.")
+        return low, True
+    except LinAlgError:
+        logger.debug(
+            "Cholesky decomposition of (P|Q) failed. Falling back to eigenvalue"
+            "decomposition."
+        )
+        d, V = eigh(j2c)  # V d V.T = (P|Q)
+        return V[:, d > 1e-14] / sqrt(d[d > 1e-14]) @ V[:, d > 1e-14].T, False
 
 
 def integral_direct_DF(mf, Fobjs, file_eri, auxbasis=None):
@@ -125,7 +155,7 @@ def integral_direct_DF(mf, Fobjs, file_eri, auxbasis=None):
         zeros((1, 3))
     )  # (P|Q) accounting for periodic images and G=0 divergence
     # TODO: reexamine kpoint, as (P|Q) depends on momentum transfer
-    low = cholesky(j2c[0], lower=True)
+    j2c, ischol = _j2c_cholesky_or_eig(j2c[0])  # TODO: kpt
 
     end = 0
     Granges = [
@@ -186,7 +216,12 @@ def integral_direct_DF(mf, Fobjs, file_eri, auxbasis=None):
     for fragidx in range(len(Fobjs)):
         logger.debug("Fitting B_{ij}^{L} for frag #%d", fragidx)
         b = pqL_frag[fragidx].reshape(auxcell.nao, -1)
-        bb = solve_triangular(low, b, lower=True, overwrite_b=True, check_finite=False)
+        if ischol:
+            bb = solve_triangular(
+                j2c, b, lower=True, overwrite_b=True, check_finite=False
+            )
+        else:
+            bb = j2c @ b
         logger.debug("Finished obtaining B_{ij}^{L} for frag #%d", fragidx)
         eri_nosym = bb.T @ bb
         if (eri_nosym.imag > 1e-6).any():

--- a/src/quemb/kbe/eri_onthefly.py
+++ b/src/quemb/kbe/eri_onthefly.py
@@ -116,10 +116,6 @@ def integral_direct_DF(mf, Fobjs, file_eri, auxbasis=None):
     coulG *= kws
 
     # Prepare storage for (pq|L) and (pq|G)
-    pqG_frag = [
-        zeros((Gv.shape[0], fragobj.nao, fragobj.nao), dtype=complex128)
-        for fragobj in Fobjs
-    ]
     pqL_frag = [
         zeros((auxcell.nao, fragobj.nao, fragobj.nao), dtype=complex128)
         for fragobj in Fobjs
@@ -146,11 +142,21 @@ def integral_direct_DF(mf, Fobjs, file_eri, auxbasis=None):
         # Transform pq (AO) to fragment space (ij)
         start = end
         end += ints.shape[0]
+
+        # Evaluate (L|G)
+        ft_auxL_Gbatch = ft_ao(chgcell, Gv[start:end])
+        ft_auxL_Gbatch = ft_auxL_Gbatch.conj().T
+
         for fragidx in range(len(Fobjs)):
             logger.debug("(μν|G) -> (ij|G) for frag #%d", fragidx)
             Gqi = ints @ Fobjs[fragidx].TA
             Giq = Gqi.transpose(0, 2, 1)
-            pqG_frag[fragidx][start:end, :, :] = Giq @ Fobjs[fragidx].TA.conj()
+            Gij = Giq @ Fobjs[fragidx].TA.conj()
+
+            # add in (L|G) (G|ij), the reciprocal space contribution
+            pqL_frag[fragidx] += (
+                ft_auxL_Gbatch @ Gij.reshape(ints.shape[0], -1)
+            ).reshape(auxcell.nao, Fobjs[fragidx].nao, Fobjs[fragidx].nao)
 
     end = 0
     blockranges = [
@@ -167,10 +173,6 @@ def integral_direct_DF(mf, Fobjs, file_eri, auxbasis=None):
         start = end
         end += ints.shape[0]
 
-        # Calculate (G|L) # TODO: can we move this and addition to pbcFS to save memory?
-        # (G|ij) is not large but also not small, as G is typically large
-        ft_auxL = ft_ao(chgcell, Gv, shls_slice=blockranges[idx])
-
         for fragidx in range(len(Fobjs)):
             logger.debug("(μν|P) -> (ij|P) for frag #%d", fragidx)
             Lqi = ints @ Fobjs[fragidx].TA
@@ -178,9 +180,7 @@ def integral_direct_DF(mf, Fobjs, file_eri, auxbasis=None):
             Lij = Liq @ Fobjs[fragidx].TA.conj()
 
             # Add in contributions from the reciprocal space
-            pqL_frag[fragidx][start:end, :, :] = Lij + (
-                ft_auxL.conj().T @ pqG_frag[fragidx].reshape(len(Gv), -1)
-            ).reshape(-1, Fobjs[fragidx].nao, Fobjs[fragidx].nao)
+            pqL_frag[fragidx][start:end, :, :] += Lij
 
     # Fit to get B_{ij}^{L}
     for fragidx in range(len(Fobjs)):

--- a/src/quemb/kbe/eri_onthefly.py
+++ b/src/quemb/kbe/eri_onthefly.py
@@ -1,0 +1,199 @@
+import logging
+
+from numpy import complex128, zeros
+from pyscf import lib
+from pyscf.ao2mo.addons import restore
+from pyscf.pbc.df.df import make_auxcell, make_modrho_basis
+from pyscf.pbc.df.ft_ao import ft_ao, ft_aopair
+from pyscf.pbc.df.gdf_builder import _CCGDFBuilder
+from pyscf.pbc.df.incore import aux_e2
+from pyscf.pbc.tools import get_coulG
+from scipy.linalg import cholesky, solve_triangular
+
+from quemb.molbe.eri_onthefly import block_step_size
+
+logger = logging.getLogger(__name__)
+
+
+def integral_direct_DF(mf, Fobjs, file_eri, auxbasis=None):
+    r"""Calculate AO density-fitted 3-center integrals on-the-fly and transform to
+    Schmidt space for given fragment objects
+
+    Parameters
+    ----------
+    mf : pyscf.scf.hf.KRHF
+        Mean-field object for the chemical system (typically BE.mf)
+    Fobjs : list of quemb.molbe.autofrag.FragPart
+        List containing fragment objects (typically BE.Fobjs)
+        The MO coefficients are taken from Frags.TA and the transformed ERIs are stored
+        in Frags.dname as h5py datasets.
+    file_eri : h5py.File
+        HDF5 file object to store the transformed fragment ERIs
+    auxbasis : str, optional
+        Auxiliary basis used for density fitting. If not provided, use pyscf's default
+        choice for the basis set used to construct mf object; by default None
+    """
+
+    def calculate_Lpq_pbcRS(aux_range):
+        r"""Internal function to calculate the 3-center integrals for a given range of
+        auxiliary indices for periodic systems (with charge compensation in real space)
+
+        Parameters
+        ----------
+        aux_range : tuple of int
+            (start index, end index) of the auxiliary basis functions
+            to calculate the 3-center integrals, i.e.
+            (:math:`(pq|L)`) with L :math:`\in [start, end)` is returned
+        """
+        logger.debug("Start calculating (μν|P) for range %s", aux_range)
+        p0, p1 = aux_range
+        shls_slice = (
+            0,
+            mf.cell.nbas,
+            0,
+            mf.cell.nbas,
+            p0,
+            p1,
+        )  # for pbc, we use aux_e2, which doesn't take in concatenated env
+
+        ints = aux_e2(
+            mf.cell,
+            auxcell,
+            mf.cell._add_suffix("int3c2e"),
+            "s1",
+            # kptij_list = , TODO: add kptij_list for k-point sampling
+            shls_slice=shls_slice,
+        ) - aux_e2(
+            mf.cell,
+            chgcell,
+            mf.cell._add_suffix("int3c2e"),
+            "s1",
+            shls_slice=shls_slice,
+        )  # Remove the part calculated in the reciprocal space to avoid double counting
+
+        logger.debug("Finish calculating (μν|P) for range %s", aux_range)
+
+        return ints.reshape(-1, mf.cell.nao, mf.cell.nao)  # TODO: ij pair to i, j
+
+    def calculate_Gpq_pbcFS(pw_range):
+        r"""Internal function to calculate the 3-center integrals for a given range of
+        plane wave indices for periodic systems (in Fourier space)
+
+        Parameters
+        ----------
+        aux_range : tuple of int
+            (start index, end index) of the plane wave basis functions
+            to calculate the 3-center integrals, i.e.
+            (:math:`(pq|G)`) with G :math:`\in [start, end)` is returned
+        """
+        logger.debug("Start calculating (μν|G) for range %s", pw_range)
+        g0, g1 = pw_range
+        Gv_batch = Gv[g0:g1]
+        coulG_batch = coulG[g0:g1]
+
+        ft_aoao_batch = ft_aopair(mf.cell, Gv_batch)  # (G, nao, nao) # TODO kpts
+
+        ints = ft_aoao_batch * coulG_batch.reshape(-1, 1, 1).conj()
+        logger.debug("Finish calculating (μν|G) for range %s", pw_range)
+
+        return ints  # (G, nao, nao)
+
+    logger.info("Evaluating fragment ERIs on-the-fly using density fitting...")
+    logger.info(
+        "In this case, note that HF-in-HF error includes DF error on top of "
+        "numerical error from embedding."
+    )
+
+    auxcell = make_auxcell(mf.cell, auxbasis)
+    chgcell = make_modrho_basis(mf.cell, auxbasis)
+
+    ccgdfbuilder = _CCGDFBuilder(mf.cell, auxcell, mf.kpts)
+    ccgdfbuilder.build()
+
+    # Prepare plane waves to evaluate in the reciprocal space for long-range contrib
+    Gv, Gv_weights, kws = mf.cell.get_Gv_weights(ccgdfbuilder.mesh)
+    coulG = get_coulG(mf.cell, mesh=ccgdfbuilder.mesh)  # kpt, exxdiv TODO
+    coulG *= kws
+
+    # Prepare storage for (pq|L) and (pq|G)
+    pqG_frag = [
+        zeros((Gv.shape[0], fragobj.nao, fragobj.nao), dtype=complex128)
+        for fragobj in Fobjs
+    ]
+    pqL_frag = [
+        zeros((auxcell.nao, fragobj.nao, fragobj.nao), dtype=complex128)
+        for fragobj in Fobjs
+    ]  # place to store fragment (pq|L)
+
+    j2c = ccgdfbuilder.get_2c2e(
+        zeros((1, 3))
+    )  # (P|Q) accounting for periodic images and G=0 divergence
+    # TODO: reexamine kpoint, as (P|Q) depends on momentum transfer
+    low = cholesky(j2c[0], lower=True)
+
+    end = 0
+    Granges = [
+        (x, y)
+        for x, y in lib.prange(
+            0,
+            len(Gv),
+            block_step_size(len(Fobjs), len(Gv), mf.cell.nao, dtype=complex128),
+        )
+    ]
+
+    for idx, ints in enumerate(lib.map_with_prefetch(calculate_Gpq_pbcFS, Granges)):
+        logger.debug("Calculating pq|G block #%d %s", idx, Granges[idx])
+        # Transform pq (AO) to fragment space (ij)
+        start = end
+        end += ints.shape[0]
+        for fragidx in range(len(Fobjs)):
+            logger.debug("(μν|G) -> (ij|G) for frag #%d", fragidx)
+            Gqi = ints @ Fobjs[fragidx].TA
+            Giq = Gqi.transpose(0, 2, 1)
+            pqG_frag[fragidx][start:end, :, :] = Giq @ Fobjs[fragidx].TA
+
+    end = 0
+    blockranges = [
+        (x, y)
+        for x, y in lib.prange(
+            0, auxcell.nbas, block_step_size(len(Fobjs), auxcell.nbas, mf.cell.nao)
+        )
+    ]
+    logger.debug("Aux Basis Block Info: %s", blockranges)
+
+    for idx, ints in enumerate(lib.map_with_prefetch(calculate_Lpq_pbcRS, blockranges)):
+        logger.debug("Calculating pq|L block #%d %s", idx, blockranges[idx])
+        # Transform pq (AO) to fragment space (ij)
+        start = end
+        end += ints.shape[0]
+
+        # Calculate (G|L) # TODO: can we move this and addition to pbcFS to save memory?
+        # (G|ij) is not large but also not small, as G is typically large
+        ft_auxL = ft_ao(chgcell, Gv, shls_slice=blockranges[idx])
+
+        for fragidx in range(len(Fobjs)):
+            logger.debug("(μν|P) -> (ij|P) for frag #%d", fragidx)
+            Lqi = ints @ Fobjs[fragidx].TA
+            Liq = Lqi.transpose(0, 2, 1)
+            Lij = Liq @ Fobjs[fragidx].TA
+
+            # Add in contributions from the reciprocal space
+            pqL_frag[fragidx][start:end, :, :] = Lij + (
+                ft_auxL.conj().T @ pqG_frag[fragidx].reshape(len(Gv), -1)
+            ).reshape(-1, Fobjs[fragidx].nao, Fobjs[fragidx].nao)
+
+    # Fit to get B_{ij}^{L}
+    for fragidx in range(len(Fobjs)):
+        logger.debug("Fitting B_{ij}^{L} for frag #%d", fragidx)
+        b = pqL_frag[fragidx].reshape(auxcell.nao, -1)
+        bb = solve_triangular(low, b, lower=True, overwrite_b=True, check_finite=False)
+        logger.debug("Finished obtaining B_{ij}^{L} for frag #%d", fragidx)
+        eri_nosym = bb.T @ bb
+        if (eri_nosym.imag > 1e-6).any():
+            raise ValueError(
+                f"Imaginary part of ERI is larger than 1e-6 for frag #{fragidx}."
+            )
+        else:
+            eri_nosym = eri_nosym.real
+        eri = restore("4", eri_nosym, Fobjs[fragidx].nao)  # TODO kpt
+        file_eri.create_dataset(Fobjs[fragidx].dname, data=eri)

--- a/src/quemb/kbe/eri_onthefly.py
+++ b/src/quemb/kbe/eri_onthefly.py
@@ -21,7 +21,7 @@ def integral_direct_DF(mf, Fobjs, file_eri, auxbasis=None):
 
     Parameters
     ----------
-    mf : pyscf.scf.hf.KRHF
+    mf : pyscf.pbc.scf.khf.KRHF
         Mean-field object for the chemical system (typically BE.mf)
     Fobjs : list of quemb.molbe.autofrag.FragPart
         List containing fragment objects (typically BE.Fobjs)

--- a/src/quemb/kbe/pbe.py
+++ b/src/quemb/kbe/pbe.py
@@ -522,8 +522,21 @@ class BE(Mixin_k_Localize):
 
         if int_transform == "out-core-DF":
             if isinstance(df_source, GDF):
-                # Use out-core transformation using libdmet
-                nprocs = self.nproc // self.ompnum
+                for fobjs_ in self.Fobjs:
+                    eri = get_emb_eri_fast_gdf(
+                        self.mf.cell,
+                        self.mf.with_df,
+                        t_reversal_symm=True,
+                        symmetry=4,
+                        C_ao_eo=fobjs_.TA,
+                    )[0]
+
+                    file_eri.create_dataset(fobjs_.dname, data=eri)
+                    eri = ao2mo.restore(8, eri, fobjs_.nao)
+                    fobjs_.cons_fock(self.hf_veff, self.S, self.hf_dm, eri_=eri)
+            else:
+                # Use cderi (Path)
+                nprocs = max(1, self.nproc // self.ompnum)
                 os.system("export OMP_NUM_THREADS=" + str(self.ompnum))
                 with ProcessPool(nprocs) as pool_:
                     results = []
@@ -544,22 +557,13 @@ class BE(Mixin_k_Localize):
                 for frg in range(self.fobj.n_frag):
                     file_eri.create_dataset(self.Fobjs[frg].dname, data=eris[frg])
                 del eris
-            else:
-                for fobjs_ in self.Fobjs:
-                    eri = get_emb_eri_fast_gdf(
-                        self.mf.cell,
-                        self.mf.with_df,
-                        t_reversal_symm=True,
-                        symmetry=4,
-                        C_ao_eo=fobjs_.TA,
-                    )[0]
-
-                    file_eri.create_dataset(fobjs_.dname, data=eri)
-                    eri = ao2mo.restore(8, eri, fobjs_.nao)
-                    fobjs_.cons_fock(self.hf_veff, self.S, self.hf_dm, eri_=eri)
         elif int_transform == "int-direct-DF":
             ensure(bool(self.auxbasis), "`auxbasis` has to be defined.")
             integral_direct_DF(self.mf, self.Fobjs, file_eri, auxbasis=self.auxbasis)
+            for fobjs_ in self.Fobjs:
+                eri = array(file_eri.get(fobjs_.dname))
+                eri = ao2mo.restore(8, eri, fobjs_.nao)
+                fobjs_.cons_fock(self.hf_veff, self.S, self.hf_dm, eri_=eri)
 
     def initialize(self, compute_hf: bool, restart: bool = False) -> None:
         """
@@ -605,7 +609,6 @@ class BE(Mixin_k_Localize):
             nprocs = self.nproc // self.ompnum
             os.system("export OMP_NUM_THREADS=" + str(self.ompnum))
 
-            nprocs = self.nproc // self.ompnum
             with ProcessPool(nprocs) as pool_:
                 results = []
                 for frg in range(self.fobj.n_frag):

--- a/src/quemb/kbe/pbe.py
+++ b/src/quemb/kbe/pbe.py
@@ -4,7 +4,7 @@ import contextlib
 import io
 import os
 import pickle
-from typing import Literal
+from typing import Literal, TypeAlias
 from warnings import warn
 
 import h5py
@@ -13,8 +13,10 @@ from numpy import array, einsum, floating, result_type, zeros, zeros_like
 from pathos.pools import ProcessPool
 from pyscf import ao2mo
 from pyscf.pbc import df, gto, scf
+from pyscf.pbc.df.df import GDF
 from pyscf.pbc.df.df_jk import _ewald_exxdiv_for_G0
 
+from quemb.kbe.eri_onthefly import integral_direct_DF
 from quemb.kbe.fragment import FragPart
 from quemb.kbe.lo import Mixin_k_Localize
 from quemb.kbe.misc import print_energy, storePBE
@@ -26,7 +28,7 @@ from quemb.molbe.solver import Solvers, UserSolverArgs, be_func
 from quemb.shared.external.optqn import (
     get_be_error_jacobian as _ext_get_be_error_jacobian,
 )
-from quemb.shared.helper import copy_docstring, timer
+from quemb.shared.helper import copy_docstring, ensure, timer
 from quemb.shared.manage_scratch import WorkDir
 from quemb.shared.typing import Matrix, PathLike
 
@@ -34,6 +36,22 @@ with contextlib.redirect_stdout(io.StringIO()):
     # Since they don't want to reduce the printing, let's temporarily disable STDOUT
     # https://github.com/gkclab/libdmet_preview/issues/22
     from libdmet.basis_transform.eri_transform import get_emb_eri_fast_gdf
+
+IntTransforms: TypeAlias = Literal[
+    "out-core-DF",
+    "int-direct-DF",
+]
+r"""Literal type describing allowed transformation strategies.
+
+- :python:`"out-core-DF"`: Use a dense, DF representation of integrals.
+  The DF integrals :math:`(\mu, \nu | P)` are stored on disc.
+  libdmet is used as the backend, which reads AO DF integrals from the
+  mean-field object (stored in disk) or cderi file (stored in disk).
+
+- :python:`"int-direct-DF"`: Use a dense, DF representation of integrals.
+  The required DF integrals :math:`(\mu, \nu | P)` are computed and fitted
+  on-demand for each fragment. Charge compensation is used for faster convergence.
+"""
 
 
 class BE(Mixin_k_Localize):
@@ -74,6 +92,8 @@ class BE(Mixin_k_Localize):
         iao_wannier: bool = False,
         thr_bath: float = 1.0e-10,
         scratch_dir: WorkDir | None = None,
+        int_transform: IntTransforms = "out-core-DF",
+        auxbasis: str | None = None,
     ) -> None:
         """
         Constructor for BE object.
@@ -130,6 +150,8 @@ class BE(Mixin_k_Localize):
 
         self.nproc = nproc
         self.ompnum = ompnum
+        self.integral_transform = int_transform
+        self.auxbasis = auxbasis
         self.thr_bath = thr_bath
 
         # Fragment information from fobj
@@ -470,6 +492,75 @@ class BE(Mixin_k_Localize):
 
         return e_.real
 
+    @timer.timeit
+    def _eri_transform(
+        self,
+        int_transform: IntTransforms,
+        df_source: PathLike | GDF | None,
+        file_eri: h5py.File,
+    ):
+        """
+        Transforms electron repulsion integrals (ERIs) for each fragment
+        and stores them in a file.
+
+        Transformation strategy follows a decision tree:
+
+        1. If cderi is passed:
+           - Use out-core transformation using libdmet.
+        2. Else, if with_df from mean-field calculation is available:
+           - Use out-core transformation using libdmet.
+        3. Else, if ``integral_direct_DF`` is requested:
+           - Use on-the-fly density-fitting integral evaluation.
+
+
+        Parameters
+        ----------
+        int_transform : The transformation strategy.
+        df_source : Source for the density-fitted integrals.
+        file_eri : The output file where transformed ERIs are stored.
+        """
+
+        if int_transform == "out-core-DF":
+            if isinstance(df_source, GDF):
+                # Use out-core transformation using libdmet
+                nprocs = self.nproc // self.ompnum
+                os.system("export OMP_NUM_THREADS=" + str(self.ompnum))
+                with ProcessPool(nprocs) as pool_:
+                    results = []
+                    for frg in range(self.fobj.n_frag):
+                        result = pool_.apipe(
+                            eritransform_parallel,
+                            self.mf.cell.a,
+                            self.mf.cell.atom,
+                            self.mf.cell.basis,
+                            self.mf.cell.unit,
+                            self.kpts,
+                            self.Fobjs[frg].TA,
+                            self.cderi,
+                        )
+                        results.append(result)
+                    eris = [result.get() for result in results]
+
+                for frg in range(self.fobj.n_frag):
+                    file_eri.create_dataset(self.Fobjs[frg].dname, data=eris[frg])
+                del eris
+            else:
+                for fobjs_ in self.Fobjs:
+                    eri = get_emb_eri_fast_gdf(
+                        self.mf.cell,
+                        self.mf.with_df,
+                        t_reversal_symm=True,
+                        symmetry=4,
+                        C_ao_eo=fobjs_.TA,
+                    )[0]
+
+                    file_eri.create_dataset(fobjs_.dname, data=eri)
+                    eri = ao2mo.restore(8, eri, fobjs_.nao)
+                    fobjs_.cons_fock(self.hf_veff, self.S, self.hf_dm, eri_=eri)
+        elif int_transform == "int-direct-DF":
+            ensure(bool(self.auxbasis), "`auxbasis` has to be defined.")
+            integral_direct_DF(self.mf, self.Fobjs, file_eri, auxbasis=self.auxbasis)
+
     def initialize(self, compute_hf: bool, restart: bool = False) -> None:
         """
         Initialize the Bootstrap Embedding calculation.
@@ -484,9 +575,6 @@ class BE(Mixin_k_Localize):
         if compute_hf:
             E_hf = 0.0
 
-        # Create a file to store ERIs
-        if not restart:
-            file_eri = h5py.File(self.eri_file, "w")
         transform_parallel = False  # hard set for now
         for fidx in range(self.fobj.n_frag):
             fobjs_ = self.fobj.to_Frags(fidx, self.eri_file, self.unitcell_nkpt)
@@ -507,21 +595,6 @@ class BE(Mixin_k_Localize):
                 self.S, self.C, self.Nocc, ncore=self.ncore
             )
 
-            if self.cderi is None:
-                if not restart:
-                    eri = get_emb_eri_fast_gdf(
-                        self.mf.cell,
-                        self.mf.with_df,
-                        t_reversal_symm=True,
-                        symmetry=4,
-                        C_ao_eo=fobjs_.TA,
-                    )[0]
-
-                    file_eri.create_dataset(fobjs_.dname, data=eri)
-                    eri = ao2mo.restore(8, eri, fobjs_.nao)
-                    fobjs_.cons_fock(self.hf_veff, self.S, self.hf_dm, eri_=eri)
-                else:
-                    eri = None
             self.Fobjs.append(fobjs_)
 
         # ERI & Fock parallelization for periodic calculations
@@ -531,26 +604,6 @@ class BE(Mixin_k_Localize):
 
             nprocs = self.nproc // self.ompnum
             os.system("export OMP_NUM_THREADS=" + str(self.ompnum))
-            with ProcessPool(nprocs) as pool_:
-                results = []
-                for frg in range(self.fobj.n_frag):
-                    result = pool_.apipe(
-                        eritransform_parallel,
-                        self.mf.cell.a,
-                        self.mf.cell.atom,
-                        self.mf.cell.basis,
-                        self.mf.cell.unit,
-                        self.kpts,
-                        self.Fobjs[frg].TA,
-                        self.cderi,
-                    )
-                    results.append(result)
-                eris = [result.get() for result in results]
-
-            for frg in range(self.fobj.n_frag):
-                file_eri.create_dataset(self.Fobjs[frg].dname, data=eris[frg])
-            del eris
-            file_eri.close()
 
             nprocs = self.nproc // self.ompnum
             with ProcessPool(nprocs) as pool_:
@@ -579,6 +632,20 @@ class BE(Mixin_k_Localize):
 
                 self.Fobjs[frg].fock = self.Fobjs[frg].h1 + veff_.real
             del veffs
+
+        # Create a file to store ERIs
+        if not restart:
+            file_eri = h5py.File(self.eri_file, "w")
+
+        # Call ERI transform
+        self._eri_transform(
+            int_transform=self.int_transform,
+            df_source=self.cderi if self.cderi else self.mf.with_df,
+            file_eri=file_eri,
+        )
+
+        if not restart:
+            file_eri.close()
 
         # SCF parallelized
         if self.nproc == 1 and not transform_parallel:

--- a/src/quemb/kbe/pbe.py
+++ b/src/quemb/kbe/pbe.py
@@ -639,7 +639,7 @@ class BE(Mixin_k_Localize):
 
         # Call ERI transform
         self._eri_transform(
-            int_transform=self.int_transform,
+            int_transform=self.integral_transform,
             df_source=self.cderi if self.cderi else self.mf.with_df,
             file_eri=file_eri,
         )

--- a/src/quemb/kbe/pbe.py
+++ b/src/quemb/kbe/pbe.py
@@ -15,6 +15,7 @@ from pyscf import ao2mo
 from pyscf.pbc import df, gto, scf
 from pyscf.pbc.df.df import GDF
 from pyscf.pbc.df.df_jk import _ewald_exxdiv_for_G0
+from pyscf.pbc.lib.kpts_helper import is_zero
 
 from quemb.kbe.eri_onthefly import integral_direct_DF
 from quemb.kbe.fragment import FragPart
@@ -223,6 +224,11 @@ class BE(Mixin_k_Localize):
             print("exxdiv = ", exxdiv, "not implemented!", flush=True)
             print("Energy may diverse.", flush=True)
             print(flush=True)
+
+        if int_transform == "int-direct-DF" and not is_zero(kpts):
+            raise NotImplementedError(
+                "k-point sampled ERI not implemented for int-direct-DF."
+            )
 
         self.frozen_core = fobj.frozen_core
         self.ncore = 0

--- a/src/quemb/molbe/eri_onthefly.py
+++ b/src/quemb/molbe/eri_onthefly.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from numpy import moveaxis, transpose, zeros
+from numpy import dtype, moveaxis, transpose, zeros
 from pyscf import lib
 from pyscf.ao2mo.addons import restore
 from pyscf.df.addons import make_auxmol
@@ -15,7 +15,7 @@ from quemb.shared.config import settings
 logger = logging.getLogger(__name__)
 
 
-def block_step_size(nfrag, naux, nao, dtype=int):
+def block_step_size(nfrag, naux, nao, datatype=float):
     """Internal function to calculate the block step size for the 3-center
     integrals calculation
 
@@ -33,7 +33,7 @@ def block_step_size(nfrag, naux, nao, dtype=int):
         int(
             settings.INTEGRAL_TRANSFORM_MAX_MEMORY
             * 1e9
-            / zeros((1), dtype=dtype).nbytes  # estimate size based on dtype
+            / dtype(datatype).itemsize  # estimate size based on dtype
             / nao
             / nao
             / naux

--- a/src/quemb/molbe/eri_onthefly.py
+++ b/src/quemb/molbe/eri_onthefly.py
@@ -15,6 +15,33 @@ from quemb.shared.config import settings
 logger = logging.getLogger(__name__)
 
 
+def block_step_size(nfrag, naux, nao, dtype=int):
+    """Internal function to calculate the block step size for the 3-center
+    integrals calculation
+
+    Parameters
+    ----------
+    nfrag : int
+        Number of fragments
+    naux : int
+        Number of auxiliary basis functions
+    nao : int
+        Number of atomic orbitals
+    """
+    return max(
+        1,
+        int(
+            settings.INTEGRAL_TRANSFORM_MAX_MEMORY
+            * 1e9
+            / zeros((1), dtype=dtype).nbytes  # estimate size based on dtype
+            / nao
+            / nao
+            / naux
+            / nfrag  # TODO: nfrag not necessary?
+        ),
+    )  # max(int(500*.24e6/8/nao),1)
+
+
 def integral_direct_DF(mf, Fobjs, file_eri, auxbasis=None):
     r"""Calculate AO density-fitted 3-center integrals on-the-fly and transform to
     Schmidt space for given fragment objects
@@ -69,32 +96,6 @@ def integral_direct_DF(mf, Fobjs, file_eri, auxbasis=None):
         )
         logger.debug("Finish calculating (μν|P) for range %s", aux_range)
         return ints
-
-    def block_step_size(nfrag, naux, nao):
-        """Internal function to calculate the block step size for the 3-center
-        integrals calculation
-
-        Parameters
-        ----------
-        nfrag : int
-            Number of fragments
-        naux : int
-            Number of auxiliary basis functions
-        nao : int
-            Number of atomic orbitals
-        """
-        return max(
-            1,
-            int(
-                settings.INTEGRAL_TRANSFORM_MAX_MEMORY
-                * 1e9
-                / 8
-                / nao
-                / nao
-                / naux
-                / nfrag
-            ),
-        )  # max(int(500*.24e6/8/nao),1)
 
     logger.info("Evaluating fragment ERIs on-the-fly using density fitting...")
     logger.info(

--- a/tests/chem_dm_kBE_test.py
+++ b/tests/chem_dm_kBE_test.py
@@ -44,6 +44,10 @@ class Test_kBE_Full(unittest.TestCase):
             cell, kpt, 1, "C2 (kBE1)", "chemgen", -102.16547952, only_chem=True
         )
 
+        self.periodic_intdirect_test(
+            cell, kpt, 1, "C2 (kBE1, int-direct-DF)", "chemgen", only_chem=True
+        )
+
     @unittest.skipUnless(
         os.getenv("QUEMB_DO_EXPENSIVE_TESTS") == "true",
         "Skipped expensive tests for QuEmb.",
@@ -159,6 +163,57 @@ class Test_kBE_Full(unittest.TestCase):
             mykbe.ebe_tot,
             target,
             msg="kBE Correlation Energy for "
+            + test_name
+            + " does not match the expected correlation energy!",
+            delta=delta,
+        )
+
+    def periodic_intdirect_test(
+        self,
+        cell,
+        kpt,
+        n_BE,
+        test_name,
+        frag_type,
+        delta=1e-4,
+        solver="CCSD",
+        only_chem=True,
+        frozen_core=False,
+    ) -> None:
+        kpts = cell.make_kpts(kpt, wrap_around=True)
+        mydf = df.GDF(cell, kpts)
+        mydf.build()
+
+        kmf = scf.KRHF(cell, kpts)
+        kmf.with_df = mydf
+        kmf.exxdiv = None
+        kmf.conv_tol = 1e-12
+        kmf.kernel()
+
+        kfrag = fragmentate(
+            n_BE=n_BE,
+            mol=cell,
+            frag_type=frag_type,
+            kpt=kpt,
+            frozen_core=frozen_core,
+        )
+        mykbe = BE(kmf, kfrag, kpts=kpts, exxdiv=None)
+        mykbe.optimize(solver=solver, only_chem=only_chem)
+
+        mykbe_intdirect = BE(
+            kmf,
+            kfrag,
+            kpts=kpts,
+            exxdiv=None,
+            int_transform="int-direct-DF",
+            auxbasis="def2-svp-jkfit",
+        )
+        mykbe_intdirect.optimize(solver=solver, only_chem=only_chem)
+
+        self.assertAlmostEqual(
+            mykbe.ebe_tot,
+            mykbe_intdirect.ebe_tot,
+            msg="kBE Correlation Energy (w/ int-direct-DF) for "
             + test_name
             + " does not match the expected correlation energy!",
             delta=delta,


### PR DESCRIPTION
While implementing #260, I realized that there are additional considerations with pbc GDF, such as avoiding the G=0 divergence. As a stepping stone, I am adding integral-direct CCGDF (analogous to the int-direct-DF in molecular code) first. This initially targets gamma point to support sparse-DF implementation, but should be easier than sparse-DF to add k-point sampling.

Future PR should take some aspects back from the PBC code to molecular code, such as `eigh` fallback option if `cholesky` fails due to non positive definite metric `(P|Q)`.