### PR TITLE
Numerical Jacobian for density matching

### DIFF
--- a/src/quemb/molbe/be_parallel.py
+++ b/src/quemb/molbe/be_parallel.py
@@ -297,10 +297,14 @@ def run_solver(
             use_cumulant,
             eri_file,
         )
-    if eeval and not ret_vec:
-        return e_f
 
-    return (e_f, mf_.mo_coeff, rdm1, rdm2s, rdm1_tmp)
+    if eeval:
+        if ret_vec:
+            return (e_f, mf_.mo_coeff, rdm1, rdm2s, rdm1_tmp)
+        else:
+            return e_f
+    else:
+        return (None, mf_.mo_coeff, rdm1, None, rdm1_tmp)
 
 
 def run_solver_u(

--- a/src/quemb/molbe/mbe.py
+++ b/src/quemb/molbe/mbe.py
@@ -897,14 +897,9 @@ class BE:
         if method == "QN":
             # Prepare the initial Jacobian matrix
             if jac_solver == "Numerical":
-                if only_chem:
-                    J0 = self.get_be_error_jacobian_numerical(
-                        only_chem, solver, relax_density, solver_args, use_cumulant
-                    )
-                else:
-                    raise NotImplementedError(
-                        "Numerical Jacobian is only implemented for only_chem=True"
-                    )
+                J0 = self.get_be_error_jacobian_numerical(
+                    only_chem, solver, relax_density, solver_args, use_cumulant
+                )
             else:
                 if only_chem:
                     J0 = array([[0.0]])
@@ -953,8 +948,6 @@ class BE:
         """
         Obtain the Jacobian matrix for BE Optimization using numerical differentiation.
         (First-order Central Finite Differences)
-        Note that this function is only implemented for the case
-        where :python:`only_chem=True`.
         """
         step_size = 1e-6  # from frankenstein
 
@@ -988,7 +981,7 @@ class BE:
                     scratch_dir=self.scratch_dir,
                     solver_args=solver_args,
                     use_cumulant=use_cumulant,
-                    eeval=False,
+                    eeval=True,  # Fix after #264 resolves
                     return_vec=True,
                 )[1]
 
@@ -1000,9 +993,18 @@ class BE:
                 ]
             )
         else:
-            raise NotImplementedError(
-                "Numerical Jacobian is only implemented for only_chem=True"
-            )
+            # TODO consider parallel dispatch
+            n_param = len(self.pot)
+            J = zeros((n_param, n_param))
+            for i in range(n_param):
+                x_plus = [0.0] * n_param
+                x_minus = [0.0] * n_param
+                x_plus[i] = step_size
+                x_minus[i] = -step_size
+                J[:, i] = (array(be_func_err(x_plus)) - array(be_func_err(x_minus))) / (
+                    2 * step_size
+                )
+            return J
 
     def print_ini(self):
         """

--- a/src/quemb/molbe/mbe.py
+++ b/src/quemb/molbe/mbe.py
@@ -900,9 +900,6 @@ class BE:
         if method == "QN":
             # Prepare the initial Jacobian matrix
             if jac_solver == "Numerical":
-                # J0 = self.get_be_error_jacobian_numerical(
-                #    only_chem, solver, relax_density, solver_args, use_cumulant
-                # ) # TODO: nproc logic
                 J0 = self.compute_numerical_jacobian(solver, only_chem, nproc)
             else:
                 if only_chem:

--- a/src/quemb/molbe/mbe.py
+++ b/src/quemb/molbe/mbe.py
@@ -814,6 +814,7 @@ class BE:
         ompnum: int = 4,
         max_iter: int = 500,
         trust_region: bool = False,
+        step_size: float = 1e-6,
         solver_args: UserSolverArgs | None = None,
     ) -> None:
         """BE optimization function
@@ -852,6 +853,8 @@ class BE:
             Options include HF, MP2, CCSD
         trust_region :
             Use trust-region based QN optimization, by default False
+        step_size :
+            Step size used in Numerical Jacobian routine, by default 1e-6
         """
         # Check if only chemical potential optimization is required
         if not only_chem:
@@ -900,7 +903,9 @@ class BE:
         if method == "QN":
             # Prepare the initial Jacobian matrix
             if jac_solver == "Numerical":
-                J0 = self.compute_numerical_jacobian(solver, only_chem, nproc)
+                J0 = self.compute_numerical_jacobian(
+                    solver, only_chem, nproc, step_size=step_size
+                )
             else:
                 if only_chem:
                     J0 = array([[0.0]])

--- a/src/quemb/molbe/mbe.py
+++ b/src/quemb/molbe/mbe.py
@@ -43,6 +43,7 @@ from quemb.molbe.lo import (
     remove_core_mo,
 )
 from quemb.molbe.misc import print_energy_cumulant, print_energy_noncumulant
+from quemb.molbe.numerical_jac import compute_numerical_jacobian
 from quemb.molbe.opt import BEOPT
 from quemb.molbe.pfrag import Frags, union_of_frag_MOs_and_index
 from quemb.molbe.solver import Solvers, UserSolverArgs, be_func
@@ -129,6 +130,8 @@ class BE:
     lo_method :
         Method for orbital localization, default is "lowdin".
     """
+
+    compute_numerical_jacobian = compute_numerical_jacobian
 
     @timer.timeit
     def __init__(
@@ -897,9 +900,10 @@ class BE:
         if method == "QN":
             # Prepare the initial Jacobian matrix
             if jac_solver == "Numerical":
-                J0 = self.get_be_error_jacobian_numerical(
-                    only_chem, solver, relax_density, solver_args, use_cumulant
-                )
+                # J0 = self.get_be_error_jacobian_numerical(
+                #    only_chem, solver, relax_density, solver_args, use_cumulant
+                # ) # TODO: nproc logic
+                J0 = self.compute_numerical_jacobian(solver, only_chem, nproc)
             else:
                 if only_chem:
                     J0 = array([[0.0]])
@@ -936,75 +940,6 @@ class BE:
     @copy_docstring(_ext_get_be_error_jacobian)
     def get_be_error_jacobian(self, jac_solver: str = "HF") -> Matrix[float64]:
         return _ext_get_be_error_jacobian(self.fobj.n_frag, self.Fobjs, jac_solver)
-
-    def get_be_error_jacobian_numerical(
-        self,
-        only_chem: bool,
-        solver: Solvers,
-        relax_density: bool,
-        solver_args: UserSolverArgs | None,
-        use_cumulant: bool,
-    ) -> Matrix[float64]:
-        """
-        Obtain the Jacobian matrix for BE Optimization using numerical differentiation.
-        (First-order Central Finite Differences)
-        """
-        step_size = 1e-6  # from frankenstein
-
-        def be_func_err(x: list[float] | None) -> float:
-            if self.nproc == 1:
-                return be_func(
-                    x,
-                    self.Fobjs,
-                    self.Nocc,
-                    solver,
-                    self.enuc,
-                    only_chem=only_chem,
-                    relax_density=relax_density,
-                    scratch_dir=self.scratch_dir,
-                    solver_args=solver_args,
-                    use_cumulant=use_cumulant,
-                    eeval=False,
-                    return_vec=True,
-                )[1]
-            else:  # parallel
-                return be_func_parallel(
-                    x,
-                    self.Fobjs,
-                    self.Nocc,
-                    solver,
-                    self.enuc,
-                    only_chem=only_chem,
-                    nproc=self.nproc,
-                    ompnum=self.ompnum,
-                    relax_density=relax_density,
-                    scratch_dir=self.scratch_dir,
-                    solver_args=solver_args,
-                    use_cumulant=use_cumulant,
-                    eeval=True,  # Fix after #264 resolves
-                    return_vec=True,
-                )[1]
-
-        if only_chem:
-            return array(
-                [
-                    (be_func_err([step_size]) - be_func_err([-step_size]))
-                    / (2 * step_size)
-                ]
-            )
-        else:
-            # TODO consider parallel dispatch
-            n_param = len(self.pot)
-            J = zeros((n_param, n_param))
-            for i in range(n_param):
-                x_plus = [0.0] * n_param
-                x_minus = [0.0] * n_param
-                x_plus[i] = step_size
-                x_minus[i] = -step_size
-                J[:, i] = (array(be_func_err(x_plus)) - array(be_func_err(x_minus))) / (
-                    2 * step_size
-                )
-            return J
 
     def print_ini(self):
         """

--- a/src/quemb/molbe/numerical_jac.py
+++ b/src/quemb/molbe/numerical_jac.py
@@ -2,15 +2,16 @@
 # To save compute, we only compute the fragments that contain the edges
 # or edges connected to the perturbed fragment's origin.
 
-from numpy import ndarray, zeros, zeros_like
+from numpy import floating, zeros, zeros_like
 
 from quemb.molbe.be_parallel import be_func_parallel, run_solver
 from quemb.molbe.solver import Solvers, be_func, solve_error
+from quemb.shared.typing import Vector
 
 
 def compute_numerical_jacobian(
     beobj, solver: Solvers, only_chem: bool, nproc: int
-) -> ndarray:
+) -> Vector[floating]:
     """Compute the numerical Jacobian for the BE optimization.
 
     This function computes the numerical Jacobian by perturbing the potentials
@@ -19,13 +20,13 @@ def compute_numerical_jacobian(
 
     Parameters
     ----------
-    beobj : BE
+    beobj
         The BE object.
-    solver : Solvers
+    solver
         The solver to use for the computation.
-    only_chem : bool
+    only_chem
         Whether to compute only the chemical potential part of the Jacobian.
-    nproc : int
+    nproc
         Number of processors to use for parallel computation.
 
     Returns

--- a/src/quemb/molbe/numerical_jac.py
+++ b/src/quemb/molbe/numerical_jac.py
@@ -31,7 +31,7 @@ def compute_numerical_jacobian(
 
     Returns
     -------
-    ndarray
+    numpy.ndarray
         The computed numerical Jacobian matrix.
     """
     step_size = 1e-6  # from frankenstein

--- a/src/quemb/molbe/numerical_jac.py
+++ b/src/quemb/molbe/numerical_jac.py
@@ -9,7 +9,7 @@ from quemb.shared.typing import Matrix
 
 
 def compute_numerical_jacobian(
-    beobj, solver: Solvers, only_chem: bool, nproc: int
+    beobj, solver: Solvers, only_chem: bool, nproc: int, step_size: float = 1e-6
 ) -> Matrix[floating]:
     """Compute the numerical Jacobian for the BE optimization.
 
@@ -33,7 +33,6 @@ def compute_numerical_jacobian(
     numpy.ndarray
         The computed numerical Jacobian matrix.
     """
-    step_size = 1e-6  # from frankenstein
     # Prepare space to store the Jacobian
     J0 = zeros((len(beobj.pot), len(beobj.pot)))
 

--- a/src/quemb/molbe/numerical_jac.py
+++ b/src/quemb/molbe/numerical_jac.py
@@ -1,0 +1,225 @@
+# Numerical Jacobian Routine
+# To save compute, we only compute the fragments that contain the edges
+# or edges connected to the perturbed fragment's origin.
+
+from numpy import ndarray, zeros, zeros_like
+
+from quemb.molbe.be_parallel import be_func_parallel, run_solver
+from quemb.molbe.solver import Solvers, be_func, solve_error
+
+
+def compute_numerical_jacobian(
+    beobj, solver: Solvers, only_chem: bool, nproc: int
+) -> ndarray:
+    """Compute the numerical Jacobian for the BE optimization.
+
+    This function computes the numerical Jacobian by perturbing the potentials
+    of the fragments that contain the edges or edges connected to the perturbed
+    fragment's origin. The Jacobian is computed using first-order central differences.
+
+    Parameters
+    ----------
+    beobj : BE
+        The BE object.
+    solver : Solvers
+        The solver to use for the computation.
+    only_chem : bool
+        Whether to compute only the chemical potential part of the Jacobian.
+    nproc : int
+        Number of processors to use for parallel computation.
+
+    Returns
+    -------
+    ndarray
+        The computed numerical Jacobian matrix.
+    """
+    step_size = 1e-6  # from frankenstein
+    # Prepare space to store the Jacobian
+    J0 = zeros((len(beobj.pot), len(beobj.pot)))
+
+    # Chem pot
+    # +x
+    x = beobj.pot.copy()
+    x[-1] += step_size
+    J0[:, -1] = chem_pot_dispatch(x, beobj, solver, only_chem, nproc)
+    # -x
+    x[-1] -= 2 * step_size
+    J0[:, -1] -= chem_pot_dispatch(x, beobj, solver, only_chem, nproc)
+    J0[:, -1] /= 2 * step_size
+
+    if only_chem:
+        return J0
+
+    # First perform oneshot calculation to get reference densities
+    if nproc == 1:
+        be_func(
+            None,
+            beobj.Fobjs,
+            beobj.Nocc,
+            solver,
+            beobj.enuc,
+            only_chem=only_chem,
+            relax_density=False,
+            scratch_dir=beobj.scratch_dir,
+            solver_args=None,
+            use_cumulant=True,
+            eeval=False,
+            return_vec=False,
+        )
+    else:
+        be_func_parallel(
+            None,
+            beobj.Fobjs,
+            beobj.Nocc,
+            solver,
+            beobj.enuc,
+            only_chem=only_chem,
+            nproc=beobj.nproc,
+            ompnum=beobj.ompnum,
+            relax_density=False,
+            scratch_dir=beobj.scratch_dir,
+            solver_args=None,
+            use_cumulant=True,
+            eeval=False,
+            return_vec=False,
+        )
+
+    # Save zero-potential 1-RDMs
+    rdm1_ref = [f._rdm1 for f in beobj.Fobjs]
+
+    # Loop over each condition
+    for idx in range(len(beobj.pot) - 1):
+        # First find which fragment the condition belongs to
+        frag_idx = sum([f.udim <= idx for f in beobj.Fobjs]) - 1
+        # Plus x
+        x = beobj.pot.copy()
+        x[idx] += step_size
+
+        # Calculate heff
+        heff = calc_heff(beobj.Fobjs[frag_idx], x, only_chem)
+        rdm1_plus = run_solver(
+            beobj.Fobjs[frag_idx].fock + heff,
+            beobj.Fobjs[frag_idx].dm0.copy(),
+            beobj.scratch_dir,
+            beobj.Fobjs[frag_idx].dname,
+            beobj.Fobjs[frag_idx].nao,
+            beobj.Fobjs[frag_idx].nsocc,
+            beobj.Fobjs[frag_idx].n_frag,
+            beobj.Fobjs[frag_idx].weight_and_relAO_per_center,
+            beobj.Fobjs[frag_idx].TA,
+            beobj.Fobjs[frag_idx].h1,
+            solver,
+            beobj.Fobjs[frag_idx].eri_file,
+            None,
+            beobj.Fobjs[frag_idx].veff0,
+            False,
+            False,
+            True,
+            False,
+            None,  # TODO: Allow passing in SolverArgs
+        )[2]
+
+        # Compute P(+x) - P(0)
+        rdm1_list = rdm1_ref.copy()
+        rdm1_list[frag_idx] = rdm1_plus
+        _, err_vec_plus = solve_error(
+            beobj.Fobjs, beobj.Nocc, only_chem, rdm1_list=rdm1_list
+        )
+
+        # Minus x
+        x[idx] -= 2 * step_size
+        heff = calc_heff(beobj.Fobjs[frag_idx], x, only_chem)
+        rdm1_minus = run_solver(
+            beobj.Fobjs[frag_idx].fock + heff,
+            beobj.Fobjs[frag_idx].dm0.copy(),
+            beobj.scratch_dir,
+            beobj.Fobjs[frag_idx].dname,
+            beobj.Fobjs[frag_idx].nao,
+            beobj.Fobjs[frag_idx].nsocc,
+            beobj.Fobjs[frag_idx].n_frag,
+            beobj.Fobjs[frag_idx].weight_and_relAO_per_center,
+            beobj.Fobjs[frag_idx].TA,
+            beobj.Fobjs[frag_idx].h1,
+            solver,
+            beobj.Fobjs[frag_idx].eri_file,
+            None,
+            beobj.Fobjs[frag_idx].veff0,
+            False,
+            False,
+            True,
+            False,
+            None,  # TODO: Allow passing in SolverArgs
+        )[2]
+
+        # Compute P(-x) - P(0)
+        rdm1_list[frag_idx] = rdm1_minus
+        _, err_vec_minus = solve_error(
+            beobj.Fobjs, beobj.Nocc, only_chem, rdm1_list=rdm1_list
+        )
+
+        # Compute central difference
+        J0[:, idx] = (err_vec_plus - err_vec_minus) / (2 * step_size)
+    return J0
+
+
+def calc_heff(fobj, pot, only_chem):
+    # This function is defined to evaluate heff without modifying the Frags object
+    # If pfrag.py::pFrag.update_heff is fixed to be side effect free, this function
+    # can be removed and the original update_heff can be used instead.
+    heff = zeros_like(fobj.h1)
+    cout = fobj.udim
+
+    for i, fi in enumerate(fobj.AO_in_frag):
+        if not any(i in sublist for sublist in fobj.relAO_per_edge):
+            heff[i, i] -= pot[-1]
+
+    if only_chem:
+        return heff
+    else:
+        for i in fobj.relAO_per_edge:
+            for j in range(len(i)):
+                for k in range(len(i)):
+                    if j > k:  # or j==k:
+                        continue
+
+                    heff[i[j], i[k]] = pot[cout]
+                    heff[i[k], i[j]] = pot[cout]
+
+                    cout += 1
+
+        return heff
+
+
+def chem_pot_dispatch(pot, beobj, solver, only_chem, nproc):
+    if nproc == 1:
+        return be_func(
+            pot,
+            beobj.Fobjs,
+            beobj.Nocc,
+            solver,
+            beobj.enuc,
+            only_chem=only_chem,
+            relax_density=False,
+            scratch_dir=beobj.scratch_dir,
+            solver_args=None,
+            use_cumulant=True,
+            eeval=False,
+            return_vec=True,
+        )[1]
+    else:
+        return be_func_parallel(
+            pot,
+            beobj.Fobjs,
+            beobj.Nocc,
+            solver,
+            beobj.enuc,
+            only_chem=only_chem,
+            nproc=beobj.nproc,
+            ompnum=beobj.ompnum,
+            relax_density=False,
+            scratch_dir=beobj.scratch_dir,
+            solver_args=None,
+            use_cumulant=True,
+            eeval=True,  # Fix after #264 resolves
+            return_vec=True,
+        )[1]

--- a/src/quemb/molbe/numerical_jac.py
+++ b/src/quemb/molbe/numerical_jac.py
@@ -1,6 +1,5 @@
 # Numerical Jacobian Routine
 # To save compute, we only compute the fragments that contain the edges
-# or edges connected to the perturbed fragment's origin.
 
 from numpy import floating, zeros, zeros_like
 

--- a/src/quemb/molbe/numerical_jac.py
+++ b/src/quemb/molbe/numerical_jac.py
@@ -81,8 +81,8 @@ def compute_numerical_jacobian(
             scratch_dir=beobj.scratch_dir,
             solver_args=None,
             use_cumulant=True,
-            eeval=False,
-            return_vec=False,
+            eeval=True,  # Fix after #264 resolves
+            return_vec=True,
         )
 
     # Save zero-potential 1-RDMs

--- a/src/quemb/molbe/numerical_jac.py
+++ b/src/quemb/molbe/numerical_jac.py
@@ -6,12 +6,12 @@ from numpy import floating, zeros, zeros_like
 
 from quemb.molbe.be_parallel import be_func_parallel, run_solver
 from quemb.molbe.solver import Solvers, be_func, solve_error
-from quemb.shared.typing import Vector
+from quemb.shared.typing import Matrix
 
 
 def compute_numerical_jacobian(
     beobj, solver: Solvers, only_chem: bool, nproc: int
-) -> Vector[floating]:
+) -> Matrix[floating]:
     """Compute the numerical Jacobian for the BE optimization.
 
     This function computes the numerical Jacobian by perturbing the potentials

--- a/src/quemb/molbe/solver.py
+++ b/src/quemb/molbe/solver.py
@@ -546,7 +546,7 @@ def be_func(
             total_e = [sum(x) for x in zip(total_e, e_f)]
             fobj.update_ebe_hf()
 
-    Ecorr = sum(total_e)
+            Ecorr = sum(total_e)
 
     if eeval and not return_vec:
         return (Ecorr, total_e)

--- a/src/quemb/molbe/solver.py
+++ b/src/quemb/molbe/solver.py
@@ -680,7 +680,7 @@ def be_func_u(
     return (E, total_e)
 
 
-def solve_error(Fobjs, Nocc, only_chem=False):
+def solve_error(Fobjs, Nocc, only_chem=False, rdm1_list=None):
     """
     Compute the error for self-consistent fragment density matrix matching.
 
@@ -702,51 +702,68 @@ def solve_error(Fobjs, Nocc, only_chem=False):
     numpy.ndarray
         Error vector.
     """
+    override_1rdm = rdm1_list is not None  # use provided 1-RDM instead
 
     err_edge = []
     err_chempot = 0.0
 
     if only_chem:
-        for fobj in Fobjs:
+        for fidx, fobj in enumerate(Fobjs):
             # Compute chemical potential error for each fragment
             for i in fobj.weight_and_relAO_per_center[1]:
-                err_chempot += fobj._rdm1[i, i]
+                if override_1rdm:
+                    err_chempot += rdm1_list[fidx][i, i]
+                else:
+                    err_chempot += fobj._rdm1[i, i]
         err_chempot /= Fobjs[0].unitcell_nkpt
         err = err_chempot - Nocc
 
         return abs(err), asarray([err])
 
     # Compute edge and chemical potential errors
-    for fobj in Fobjs:
+    for fidx, fobj in enumerate(Fobjs):
         # match rdm-edge
         for edge in fobj.relAO_per_edge:
             for j_ in range(len(edge)):
                 for k_ in range(len(edge)):
                     if j_ > k_:
                         continue
-                    err_edge.append(fobj._rdm1[edge[j_], edge[k_]])
+                    if override_1rdm:
+                        err_edge.append(rdm1_list[fidx][edge[j_], edge[k_]])
+                    else:
+                        err_edge.append(fobj._rdm1[edge[j_], edge[k_]])
         # chem potential
         for i in fobj.weight_and_relAO_per_center[1]:
-            err_chempot += fobj._rdm1[i, i]
+            if override_1rdm:
+                err_chempot += rdm1_list[fidx][i, i]
+            else:
+                err_chempot += fobj._rdm1[i, i]
 
     err_chempot /= Fobjs[0].unitcell_nkpt
     err_edge.append(err_chempot)  # far-end edges are included as err_chempot
 
     # Compute center errors
     err_cen = []
-    for findx, fobj in enumerate(Fobjs):
+    for fobj in Fobjs:
         # Match RDM for centers
-        for cindx, cens in enumerate(fobj.relAO_in_ref_per_edge):
+        for cidx, cens in enumerate(fobj.relAO_in_ref_per_edge):
             lenc = len(cens)
             for j_ in range(lenc):
                 for k_ in range(lenc):
                     if j_ > k_:
                         continue
-                    err_cen.append(
-                        Fobjs[fobj.ref_frag_idx_per_edge[cindx]]._rdm1[
-                            cens[j_], cens[k_]
-                        ]
-                    )
+                    if override_1rdm:
+                        err_cen.append(
+                            rdm1_list[fobj.ref_frag_idx_per_edge[cidx]][
+                                cens[j_], cens[k_]
+                            ]
+                        )
+                    else:
+                        err_cen.append(
+                            Fobjs[fobj.ref_frag_idx_per_edge[cidx]]._rdm1[
+                                cens[j_], cens[k_]
+                            ]
+                        )
 
     err_cen.append(Nocc)
     err_edge = array(err_edge)

--- a/src/quemb/molbe/solver.py
+++ b/src/quemb/molbe/solver.py
@@ -546,7 +546,7 @@ def be_func(
             total_e = [sum(x) for x in zip(total_e, e_f)]
             fobj.update_ebe_hf()
 
-            Ecorr = sum(total_e)
+    Ecorr = sum(total_e)
 
     if eeval and not return_vec:
         return (Ecorr, total_e)

--- a/tests/numerical_jac_test.py
+++ b/tests/numerical_jac_test.py
@@ -1,0 +1,69 @@
+import os
+import unittest
+
+import numpy
+from pyscf.gto import Mole
+from pyscf.scf.hf import RHF
+
+from quemb.molbe import BE, fragmentate
+from quemb.molbe.chemfrag import ChemGenArgs
+
+
+class Test_Num_Jac(unittest.TestCase):
+    def build_BE_object(self, mol, n_BE, h_treatment="treat_H_diff"):
+        mf = RHF(mol)
+        mf.kernel()
+        fobj = fragmentate(
+            mol,
+            n_BE=n_BE,
+            frag_type="chemgen",
+            additional_args=ChemGenArgs(h_treatment=h_treatment),
+        )
+        return BE(mf, fobj, nproc=48, ompnum=8)
+
+    @unittest.skipUnless(
+        os.getenv("QUEMB_DO_EXPENSIVE_TESTS") == "true",
+        "Skipped expensive tests for QuEmb.",
+    )
+    def test_numerical_jacobian_octane(self):
+        mol = Mole()
+        mol.atom = "./xyz/distorted_octane.xyz"
+        mol.basis = "sto-3g"
+        mol.build()
+        beobj = self.build_BE_object(mol, n_BE=2)
+
+        beobj.optimize(
+            solver="CCSD", only_chem=False, jac_solver="Numerical", nproc=48, ompnum=8
+        )
+        analytical_ebe = beobj.ebe_tot
+
+        beobj.optimize(
+            solver="CCSD", only_chem=False, jac_solver="HF", nproc=48, ompnum=8
+        )
+        numerical_ebe = beobj.ebe_tot
+
+        self.assertTrue(numpy.allclose(analytical_ebe, numerical_ebe, atol=1e-5))
+
+    def test_numerical_jacobian_h8(self):
+        mol = Mole()
+        mol.atom = [["H", (0.0, 0.0, i)] for i in range(7)]
+        mol.atom.append(["H", (0.0, 0.0, 4.2)])
+        mol.basis = "sto-3g"
+        mol.build()
+        beobj = self.build_BE_object(mol, n_BE=2, h_treatment="treat_H_like_heavy_atom")
+
+        beobj.optimize(
+            solver="CCSD", only_chem=False, jac_solver="Numerical", nproc=48, ompnum=8
+        )
+        analytical_ebe = beobj.ebe_tot
+
+        beobj.optimize(
+            solver="CCSD", only_chem=False, jac_solver="HF", nproc=48, ompnum=8
+        )
+        numerical_ebe = beobj.ebe_tot
+
+        self.assertTrue(numpy.allclose(analytical_ebe, numerical_ebe, atol=1e-5))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/numerical_jac_test.py
+++ b/tests/numerical_jac_test.py
@@ -33,12 +33,12 @@ class Test_Num_Jac(unittest.TestCase):
         beobj = self.build_BE_object(mol, n_BE=2)
 
         beobj.optimize(
-            solver="CCSD", only_chem=False, jac_solver="Numerical", nproc=48, ompnum=8
+            solver="MP2", only_chem=False, jac_solver="Numerical", nproc=48, ompnum=8
         )
         analytical_ebe = beobj.ebe_tot
 
         beobj.optimize(
-            solver="CCSD", only_chem=False, jac_solver="HF", nproc=48, ompnum=8
+            solver="MP2", only_chem=False, jac_solver="HF", nproc=48, ompnum=8
         )
         numerical_ebe = beobj.ebe_tot
 


### PR DESCRIPTION
This PR adds on to #250 and allows numerical Jacobian routine for density matching. While this is much slower than existing analytical options, it is helpful for problems that are very difficult to converge.

Subsequent PR will replace the for loop in compute_numerical_jacobian::91 to a parallel dispatch.

Resolves #34