### PR TITLE
Fix atol for failing localization tests to reflect BE optimization tolerance.

### DIFF
--- a/tests/loc_test.py
+++ b/tests/loc_test.py
@@ -1,6 +1,5 @@
 # Tests the standard localization and IAO routines for hexene
 
-import os
 import unittest
 from typing import Literal
 
@@ -28,7 +27,8 @@ def test_hexene_loc_be1_froz_pm(hexene) -> None:
 
 
 @unittest.skipUnless(
-    os.getenv("QUEMB_DO_EXPENSIVE_TESTS") == "true",
+    True,
+    # os.getenv("QUEMB_DO_EXPENSIVE_TESTS") == "true",
     "Skipped expensive tests for QuEmb.",
 )
 def test_hexene_loc_be2_unfroz_lowdin(hexene) -> None:
@@ -42,7 +42,7 @@ def test_hexene_loc_be2_unfroz_lowdin(hexene) -> None:
         oneshot=True,
         nproc=2,
     )
-    assert np.isclose(be2_nf_lo, -0.94588487)
+    assert np.isclose(be2_nf_lo, -0.94588487, atol=2e-6, rtol=0)
 
 
 def test_hexene_loc_be1_unfroz_iao_minao_so(hexene) -> None:
@@ -57,11 +57,12 @@ def test_hexene_loc_be1_unfroz_iao_minao_so(hexene) -> None:
         oneshot=True,
         nproc=1,
     )
-    assert np.isclose(be1_nf_iao_so, -0.83985647)
+    assert np.isclose(be1_nf_iao_so, -0.83985647, atol=2e-6, rtol=0)
 
 
 @unittest.skipUnless(
-    os.getenv("QUEMB_DO_EXPENSIVE_TESTS") == "true",
+    True,
+    # os.getenv("QUEMB_DO_EXPENSIVE_TESTS") == "true",
     "Skipped expensive tests for QuEmb.",
 )
 def test_hexene_loc_be2_froz_iao_sto3g_boys(hexene) -> None:
@@ -77,13 +78,14 @@ def test_hexene_loc_be2_froz_iao_sto3g_boys(hexene) -> None:
         nproc=8,
     )
     # energy after four iterations
-    assert np.isclose(be2_f_iao_fb, -0.92794903, atol=1e-8, rtol=0), be2_f_iao_fb
+    assert np.isclose(be2_f_iao_fb, -0.92794903, atol=2e-6, rtol=0), be2_f_iao_fb
     # Oneshot energy
     # assert np.isclose(be2_f_iao_fb, -0.92843714)
 
 
 @unittest.skipUnless(
-    os.getenv("QUEMB_DO_EXPENSIVE_TESTS") == "true",
+    True,
+    # os.getenv("QUEMB_DO_EXPENSIVE_TESTS") == "true",
     "Skipped expensive tests for QuEmb.",
 )
 def test_chem_gen_hexene_loc_be2_froz_iao_sto3g_boys(hexene) -> None:
@@ -101,11 +103,12 @@ def test_chem_gen_hexene_loc_be2_froz_iao_sto3g_boys(hexene) -> None:
         additional_args=ChemGenArgs(wrong_iao_indexing=True),
     )
     # energy after four iterations
-    assert np.isclose(be2_f_iao_fb, -0.92794903, atol=1e-8, rtol=0), be2_f_iao_fb
+    assert np.isclose(be2_f_iao_fb, -0.92794903, atol=2e-6, rtol=0), be2_f_iao_fb
 
 
 @unittest.skipUnless(
-    os.getenv("QUEMB_DO_EXPENSIVE_TESTS") == "true",
+    True,
+    # os.getenv("QUEMB_DO_EXPENSIVE_TESTS") == "true",
     "Skipped expensive tests for QuEmb.",
 )
 def test_chem_gen_hexene_loc_be2_froz_iao_sto3g_boys_fixed_AOs(hexene) -> None:
@@ -122,7 +125,7 @@ def test_chem_gen_hexene_loc_be2_froz_iao_sto3g_boys_fixed_AOs(hexene) -> None:
         frag_type="chemgen",
         additional_args=ChemGenArgs(wrong_iao_indexing=False),
     )
-    assert np.isclose(be2_f_iao_fb, -0.9279496397090554, atol=1e-8, rtol=0)
+    assert np.isclose(be2_f_iao_fb, -0.9279496397090554, atol=2e-6, rtol=0)
 
 
 def ret_ecorr(


### PR DESCRIPTION
There are some failing tests in the localization tests. Superficially, this comes from numerical error coming from new numpy version. The failing tests compare the optimized BE correlation energy, which are only converged to 1e-6. Tests were applied with atol = 1e-8 and rtol = 0, and therefore failed due to an order 1e-6 error. We should apply tolerance that we can expect from the BE optimization routine, rather than a overly strict criteria.