### PR TITLE
Fixed issue 258: updated dependency for chemcoord

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "numba",
     "ordered-set",
     "libdmet @ git+https://github.com/gkclab/libdmet_preview.git",
-    "chemcoord @ git+https://github.com/mcocdawc/chemcoord.git",
+    "chemcoord>=2.2.0",
     "pathos",
 ]
 

--- a/src/quemb/molbe/graphfrag.py
+++ b/src/quemb/molbe/graphfrag.py
@@ -198,7 +198,7 @@ class GraphGenUtility:
         - Arcs between nodes are radially offset to distinguish overlapping edges.
         """
         z_offset = 0.5
-        c_ = plt.cm.get_cmap(cmap) # type: ignore[attr-defined]
+        c_ = plt.cm.get_cmap(cmap)  # type: ignore[attr-defined]
         c = [c_(fdx / len(edge_list))[0:3] for fdx in range(0, len(edge_list))]
         patches = [mpatches.Patch(color=color, alpha=0.9) for color in c]
         labels = {adx: (map["label"] + str(adx)) for adx, map in adx_map.items()}

--- a/src/quemb/molbe/graphfrag.py
+++ b/src/quemb/molbe/graphfrag.py
@@ -198,7 +198,7 @@ class GraphGenUtility:
         - Arcs between nodes are radially offset to distinguish overlapping edges.
         """
         z_offset = 0.5
-        c_ = plt.cm.get_cmap(cmap)
+        c_ = plt.cm.get_cmap(cmap) # type: ignore[attr-defined]
         c = [c_(fdx / len(edge_list))[0:3] for fdx in range(0, len(edge_list))]
         patches = [mpatches.Patch(color=color, alpha=0.9) for color in c]
         labels = {adx: (map["label"] + str(adx)) for adx, map in adx_map.items()}


### PR DESCRIPTION
Tested that changing to `pandas >= 3.0.0 chemcoord >= 2.2.0` still passes the tests. Preferred dependencies on pyproject.toml changed to `chemcoord>=2.2.0`. Per [chemfrag all-to-all connectivity test fails
 #258](https://github.com/troyvvgroup/quemb/issues/258) comment from @mcocdawc, pandas isn't on the dependency list. 

Resolves #258 